### PR TITLE
Prevent aggressive div flattening to preserve block structure

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,8 @@ export const PRESERVE_ELEMENTS = new Set([
 // Inline elements that should not be unwrapped
 export const INLINE_ELEMENTS = new Set([
 	'a', 'span', 'strong', 'em', 'i', 'b', 'u', 'code', 'br', 'small',
-	'sub', 'sup', 'mark', 'del', 'ins', 'q', 'abbr', 'cite', 'time'
+	'sub', 'sup', 'mark', 'del', 'ins', 'q', 'abbr', 'cite', 'time',
+	'font'
 ]);
 
 // Hidden elements that should be removed

--- a/src/defuddle.ts
+++ b/src/defuddle.ts
@@ -518,6 +518,22 @@ export class Defuddle {
 		// Process in batches to maintain performance
 		let keepProcessing = true;
 
+		// Helper function to check if an element directly contains inline content
+		// This helps prevent unwrapping divs that visually act as paragraphs.
+		function hasDirectInlineContent(el: Element): boolean {
+			for (const child of el.childNodes) {
+				// Check for non-empty text nodes
+				if (child.nodeType === Node.TEXT_NODE && child.textContent?.trim()) {
+					return true;
+				}
+				// Check for element nodes that are considered inline
+				if (child.nodeType === Node.ELEMENT_NODE && INLINE_ELEMENTS.has(child.nodeName.toLowerCase())) {
+					return true;
+				}
+			}
+			return false;
+		}
+
 		const shouldPreserveElement = (el: Element): boolean => {
 			const tagName = el.tagName.toLowerCase();
 			
@@ -552,6 +568,11 @@ export class Defuddle {
 		};
 
 		const isWrapperDiv = (div: Element): boolean => {
+			// If it directly contains inline content, it's NOT a wrapper
+			if (hasDirectInlineContent(div)) {
+				return false;
+			}
+
 			// Check if it's just empty space
 			if (!div.textContent?.trim()) return true;
 
@@ -650,22 +671,31 @@ export class Defuddle {
 				return true;
 			}
 
-			// Case 4: Div only contains text content - convert to paragraph
-			if (!div.children.length && div.textContent?.trim()) {
+			// Case 4: Div only contains text and/or inline elements - convert to paragraph
+			const childNodes = Array.from(div.childNodes);
+			const hasOnlyInlineOrText = childNodes.length > 0 && childNodes.every(child =>
+				(child.nodeType === Node.TEXT_NODE) ||
+				(child.nodeType === Node.ELEMENT_NODE && INLINE_ELEMENTS.has(child.nodeName.toLowerCase()))
+			);
+
+			if (hasOnlyInlineOrText && div.textContent?.trim()) { // Ensure there's actual content
 				const p = this.doc.createElement('p');
-				p.textContent = div.textContent;
+				// Move all children (including inline tags like <font>) to the new <p>
+				while (div.firstChild) {
+					p.appendChild(div.firstChild);
+				}
 				div.replaceWith(p);
 				processedCount++;
 				return true;
 			}
 
-			// Case 5: Div has single child
+			// Case 5: Div has single child - unwrap only if child is block-level
 			if (div.children.length === 1) {
 				const child = div.firstElementChild!;
 				const childTag = child.tagName.toLowerCase();
 				
-				// Don't unwrap if child is inline or should be preserved
-				if (!INLINE_ELEMENTS.has(childTag) && !shouldPreserveElement(child)) {
+				// Only unwrap if the single child is a block element and not preserved
+				if (BLOCK_ELEMENTS.includes(childTag) && !shouldPreserveElement(child)) {
 					div.replaceWith(child);
 					processedCount++;
 					return true;
@@ -682,7 +712,8 @@ export class Defuddle {
 				parent = parent.parentElement;
 			}
 
-			if (nestingDepth > 0) { // Changed from > 1 to > 0 to be more aggressive
+			// Only unwrap if nested AND does not contain direct inline content
+			if (nestingDepth > 0 && !hasDirectInlineContent(div)) {
 				const fragment = this.doc.createDocumentFragment();
 				while (div.firstChild) {
 					fragment.appendChild(div.firstChild);
@@ -742,18 +773,22 @@ export class Defuddle {
 			let modified = false;
 			
 			remainingDivs.forEach(div => {
-				// Check if div only contains paragraphs
-				const children = Array.from(div.children);
-				const onlyParagraphs = children.every(child => child.tagName.toLowerCase() === 'p');
-				
-				if (onlyParagraphs || (!shouldPreserveElement(div) && isWrapperDiv(div))) {
-					const fragment = this.doc.createDocumentFragment();
-					while (div.firstChild) {
-						fragment.appendChild(div.firstChild);
+				// Only perform final cleanup/unwrap if the div is still connected,
+				// not preserved, and does not contain direct inline content.
+				if (div.isConnected && !shouldPreserveElement(div) && !hasDirectInlineContent(div)) {
+					const children = Array.from(div.children);
+					const onlyParagraphs = children.length > 0 && children.every(child => child.tagName.toLowerCase() === 'p');
+
+					// Unwrap if it only contains paragraphs OR is identified as a wrapper
+					if (onlyParagraphs || isWrapperDiv(div)) {
+						const fragment = this.doc.createDocumentFragment();
+						while (div.firstChild) {
+							fragment.appendChild(div.firstChild);
+						}
+						div.replaceWith(fragment);
+						processedCount++;
+						modified = true;
 					}
-					div.replaceWith(fragment);
-					processedCount++;
-					modified = true;
 				}
 			});
 			return modified;


### PR DESCRIPTION
This PR addresses an issue where the `flattenDivs` cleanup routine in Defuddle was too aggressive in unwrapping `<div>` elements, causing consecutive divs that should render as separate paragraphs to merge into a single line. This was particularly noticeable for divs containing simple inline content like text or `<font>` tags.

**Problem:**

The previous `flattenDivs` logic contained heuristics (e.g., identifying "wrapper" divs, unwrapping nested divs, or handling single-child divs) that didn't adequately check if the `<div>` itself held meaningful inline content. This led to the removal of the `<div>` container, loss of its block-level separation, and subsequent merging of content by whitespace cleanup routines.

**Solution:**

This PR makes the `flattenDivs` logic more conservative by introducing checks to protect divs that carry direct content:

1.  **Added `font` to `INLINE_ELEMENTS`:** Recognizes `<font>` tags as inline content.
2.  **Introduced `hasDirectInlineContent` check:** A helper function was added (as a private class method) to determine if an element directly contains non-empty text nodes or known inline elements.
3.  **Modified `flattenDivs` Cases:** The logic for unwrapping divs (potential wrappers, nested divs, single-child divs, final cleanup) has been updated to **only** proceed if the `div` **does not** have direct inline content according to `hasDirectInlineContent`.
4.  **Improved `div` to `<p>` Conversion:** The logic for converting simple `div` elements to `<p>` now correctly handles divs containing inline tags (like `<font>`), moving the entire content into the new paragraph.
5.  **Refined Single Child Unwrapping:** Ensures divs are only unwrapped if their single child is a block-level element.

**Result:**

`<div>` elements containing text or inline formatting (like the example `<div><font>Line 1</font></div><div><font>Line 2</font></div>`) are now less likely to be flattened, preserving their intended block structure and preventing them from merging into a single line. The cleanup prioritizes retaining the visual paragraph separation provided by these divs.

**Testing:**

I've manually tested it on local Obsidian Clipper builds, which preserving the format of [this page](https://home.gamer.com.tw/creationDetail.php?sn=3614863) correctly.

This PR was co-authored with Gemini 2.5 Pro.
