### PR TITLE
Fix references to DOM globals not present in node context

### DIFF
--- a/src/elements/code.ts
+++ b/src/elements/code.ts
@@ -119,6 +119,10 @@ const CODE_LANGUAGES = new Set([
 	'zig'
 ]);
 
+function isElement(node: Node): node is Element {
+	return node.nodeType === NODE_TYPE.ELEMENT_NODE;
+}
+
 // Convert code blocks with different syntax highlighters and line numbers
 // to a standard <pre> and <code> element with a language attribute
 export const codeBlockRules = [
@@ -243,7 +247,7 @@ export const codeBlockRules = [
 				}
 				
 				let text = '';
-				if (element instanceof HTMLElement) {
+				if (isElement(element)) {
 					// Handle explicit line breaks
 					if (element.tagName === 'BR') {
 						return '\n';

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -586,9 +586,8 @@ export function createMarkdownContent(content: string, url: string) {
 					element.removeAttribute(attr.name);
 				}
 			});
-			
 			element.childNodes.forEach(child => {
-				if (child instanceof Element) {
+				if (isElement(child)) {
 					cleanElement(child);
 				}
 			});


### PR DESCRIPTION
This PR fixes references to DOM globals when running in node context. It's basically the same problems raised in #4, but it appears that you probably missed in your node fixes leading up to [v5.0.4](https://github.com/kepano/defuddle/tree/0.5.4)  (65713b4...baec5c2).

I encountered the problem, when I was processing the docs of Pester locally via defuddle-cli. I built the docs locally, but here's the links to the pages, where the parsing failed. 

- for markdown.ts: https://pester.dev/docs/additional-resources/projects
- for code.ts:  https://pester.dev/docs/assertions/should-command

Let me know whether you need more info.