### PR TITLE
Remove child combinator in :has selector

### DIFF
--- a/src/elements/images.ts
+++ b/src/elements/images.ts
@@ -184,7 +184,7 @@ export const imageRules = [
 	
 	// Standardize complex image elements (figure, picture, source, figcaption)
 	{
-		selector: 'figure, p:has(> [class*="caption"])',
+		selector: 'figure, p:has([class*="caption"])',
 		element: 'figure',
 		transform: (el: Element, doc: Document): Element => {
 			try {


### PR DESCRIPTION
When running with defuddle-cli I ran into this error:

```bash
Defuddle Error processing document: DOMException [SyntaxError]: ':scope >[class*="caption"]' is not a valid selector
    at emit (/Users/vurral/src/defuddle/node_modules/nwsapi/src/nwsapi.js:669:17)
    at parse (/Users/vurral/src/defuddle/node_modules/nwsapi/src/nwsapi.js:1541:9)
    at _querySelectorAll (/Users/vurral/src/defuddle/node_modules/nwsapi/src/nwsapi.js:1623:21)
    at Object._querySelector [as first] (/Users/vurral/src/defuddle/node_modules/nwsapi/src/nwsapi.js:1571:14)
    at HTMLParagraphElementImpl.querySelector (/Users/vurral/src/defuddle/node_modules/jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:69:44)
    at HTMLParagraphElement.querySelector (/Users/vurral/src/defuddle/node_modules/jsdom/lib/jsdom/living/generated/Element.js:1094:58)
    at Array.Resolver (eval at compile (/Users/vurral/src/defuddle/node_modules/nwsapi/src/nwsapi.js:871:17), <anonymous>:3:104)
    at collect (/Users/vurral/src/defuddle/node_modules/nwsapi/src/nwsapi.js:1679:21)
    at Object._querySelectorAll [as select] (/Users/vurral/src/defuddle/node_modules/nwsapi/src/nwsapi.js:1634:36)
    at HTMLElementImpl.querySelectorAll (/Users/vurral/src/defuddle/node_modules/jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:78:26)
 ```
 
NWSAPI, the CSS selectors engine used by JSDOM, has an open issues regarding the `:has()` selector not being fully supported yet: https://github.com/dperini/nwsapi/issues/145
 
It seems that removing the child combinator `>` fixes the issue.

Let me know whether you want me to open an issue for this pull request.
 
    