### PR TITLE
Added support for optional Markdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ The core bundle is recommended for most use cases. It still handles math content
 
 ## Options
 
+| Option                   | Type    | Description                                                                     |
+|--------------------------|---------|---------------------------------------------------------------------------------|
+| `debug`                  | boolean | Enable debug logging                                                            |
+| `url`                    | string  | URL of the page being parsed                                                    |
+| `markdown`               | boolean | Convert output to markdown                                                      |
+| `includeMarkdown`        | boolean | Include markdown in the response                                                |
+| `removeExactSelectors`   | boolean | Whether to remove elements matching exact selectors like ads, social buttons, etc. Defaults to true. |
+| `removePartialSelectors` | boolean | Whether to remove elements matching partial selectors like ads, social buttons, etc. Defaults to true. |
+
 ### Debug mode
 
 You can enable debug mode by passing an options object when creating a new Defuddle instance:

--- a/src/node.ts
+++ b/src/node.ts
@@ -33,18 +33,21 @@ export async function Defuddle(
 		dom = htmlOrDom;
 	}
 
+	const pageUrl = url || dom.window.location.href;
+
 	// Create Defuddle instance with URL in options
 	const defuddle = new DefuddleClass(dom.window.document, {
 		...options,
-		url: url || dom.window.location.href
+		url: pageUrl
 	});
 
 	const result = defuddle.parse();
 
 	// Convert to markdown if requested
 	if (options?.markdown) {
-		const pageUrl = url || dom.window.location.href;
 		result.content = createMarkdownContent(result.content, pageUrl);
+	} else if (options?.includeMarkdown) {
+		result.contentMarkdown = createMarkdownContent(result.content, pageUrl);
 	}
 
 	return result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface DefuddleMetadata {
 
 export interface DefuddleResponse extends DefuddleMetadata {
 	content: string;
+	contentMarkdown?: string;
 	extractorType?: string;
 }
 
@@ -32,6 +33,11 @@ export interface DefuddleOptions {
 	 * Convert output to markdown
 	 */
 	markdown?: boolean;
+
+	/**
+	 * Include markdown in the response
+	 */
+	includeMarkdown?: boolean;
 
 	/**
 	 * Whether to remove elements matching exact selectors like ads, social buttons, etc.


### PR DESCRIPTION
It would be helpful to have `content` as HTML, or `content` as markdown, or `content` as HTML and `contentMarkdown` as markdown. So I added an option `includeMarkdown` that does that, only if `markdown` is false or not set.

I also added the options reference table in the README.