### PR TITLE
fix(markdown): convert relative URLs to absolute in createMarkdownCon…

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -187,7 +187,18 @@ export function createMarkdownContent(content: string, url: string) {
 			if (!img || !isGenericElement(img)) return content;
 
 			const alt = img.getAttribute('alt') || '';
-			const src = img.getAttribute('src') || '';
+			let src = img.getAttribute('src') || '';
+
+			// Check if the src is a relative URL and convert it to an absolute URL if needed
+			if (src && !src.startsWith("http")) {
+				try {
+					const baseUrl = new URL(url);
+					src = new URL(src, baseUrl).href;
+				} catch (e) {
+					console.error("Invalid base URL:", url);
+				}
+			}
+			
 			let caption = '';
 
 			if (figcaption && isGenericElement(figcaption)) {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -295,6 +295,15 @@ export function createMarkdownContent(content: string, url: string) {
 			if (!isGenericElement(node)) return content;
 			const href = node.getAttribute('href');
 			const title = node.getAttribute('title');
+
+			if (href && !href.startsWith("http")) {
+			      try {
+      					  const baseUrl = new URL(url); // 确保 'url' 是基准 URL
+  					      href = new URL(href, baseUrl).href;
+ 				   } catch (e) {
+		      			  console.error("Invalid base URL:", url);
+		    	   }
+		 	}
 			
 			// Extract the heading
 			const headingNode = node.querySelector('h1, h2, h3, h4, h5, h6');


### PR DESCRIPTION
When a source URL is relative, it is now converted to an absolute URL using the base URL provided. This ensures all URLs are valid and absolute.