### PR TITLE
fixed unexpected behavior with newlines in <p> tags

### DIFF
--- a/src/standardize.ts
+++ b/src/standardize.ts
@@ -531,8 +531,19 @@ function removeEmptyLines(element: Element, doc: Document): void {
 				node.parentNode?.removeChild(node);
 				removedCount++;
 			} else {
+				
+				let newText = text;
+
+				if (node.parentElement){
+					const styles = node.parentElement.style;
+					if (!styles.whiteSpace || styles.whiteSpace == "normal" ) {
+						// replace newlines with spaces as per the white-space property
+						newText = newText.replace(/\n/g, ' ')
+					}
+				}
+
 				// Clean up the text content while preserving important spaces
-				const newText = text
+				newText = newText
 					.replace(/\n{3,}/g, '\n\n') // More than 2 newlines -> 2 newlines
 					.replace(/^[\n\r\t]+/, '') // Remove leading newlines/tabs (preserve spaces)
 					.replace(/[\n\r\t]+$/, '') // Remove trailing newlines/tabs (preserve spaces)


### PR DESCRIPTION
Fixes https://github.com/kepano/defuddle/issues/84 and https://github.com/obsidianmd/obsidian-clipper/issues/592 (downstream).

When standardizing text, it checks the `white-space` CSS property, and handles newlines accordingly. 