### PR TITLE
Fix test being timezone dependant

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"dev:js": "webpack --watch --mode development",
 		"dev:node": "tsc --project tsconfig.node.json --watch",
 		"dev": "npm run clean && npm run build:types && concurrently \"npm run dev:types\" \"npm run dev:node\" \"npm run dev:js\"",
-		"test": "vitest run",
+		"test": "TZ=UTC vitest run",
 		"playground": "node playground/server.js"
 	},
 	"keywords": [

--- a/tests/expected/github.com-issue-56.md
+++ b/tests/expected/github.com-issue-56.md
@@ -44,7 +44,7 @@ Defuddle Error processing document: TypeError: e3.getComputedStyle is not a func
 
 If you feel like there's nothing to do, or supporting Workers is out-of-scope for the project, feel free to close the issue
 
-**jmorrell** commented on 5/26/2025
+**jmorrell** commented on 5/25/2025
 
 For my use-case, I'm already running a headless [browser rendering worker](https://developers.cloudflare.com/browser-rendering/) to load the page anyway. Instead of downloading the HTML content from the browser and then trying to process it in the worker, I can load defuddle in the browser itself with the page loaded and execute it there. This is a little more awkward but seems to work pretty well!
 


### PR DESCRIPTION
When I ran `npm test` locally I was getting a diff, but this turns out to be due to the usage of `toLocaleDateString()`. This PR fixes that by enforcing all tests run with a UTC timezone.