### PR TITLE
Fix X author fallback on status URLs

### DIFF
--- a/src/extractors/x-article.ts
+++ b/src/extractors/x-article.ts
@@ -69,8 +69,9 @@ export class XArticleExtractor extends BaseExtractor {
 	}
 
 	private getAuthorFromUrl(): string {
-		// match username before /article/, excluding system paths like /i/
-		const match = this.url.match(/\/([a-zA-Z][a-zA-Z0-9_]{0,14})\/article\/\d+/);
+		// X articles can render on both /article/ and /status/ URLs.
+		// Prefer the handle from the URL when available, excluding system paths like /i/.
+		const match = this.url.match(/\/([a-zA-Z][a-zA-Z0-9_]{0,14})\/(?:status|article)\/\d+/);
 		return match ? `@${match[1]}` : this.getAuthorFromOgTitle();
 	}
 

--- a/tests/expected/general--x.com-status-localized-author.md
+++ b/tests/expected/general--x.com-status-localized-author.md
@@ -1,0 +1,12 @@
+```json
+{
+  "title": "Localized author fallback example",
+  "author": "@sample_user",
+  "site": "X (Twitter)",
+  "published": ""
+}
+```
+
+This fixture simulates an X article rendered on a status URL without an inline author block.
+
+The author should fall back to the handle embedded in the page URL.

--- a/tests/fixtures/general--x.com-status-localized-author.html
+++ b/tests/fixtures/general--x.com-status-localized-author.html
@@ -1,0 +1,24 @@
+<!-- {"url":"https://x.com/sample_user/status/1234567890123456789"} -->
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta property="og:title" content="X 上的 Sample Name：“Localized author fallback example” / X">
+    <title>X 上的 Sample Name：“Localized author fallback example” / X</title>
+</head>
+<body>
+    <div data-testid="twitter-article-title">Localized author fallback example</div>
+    <div data-testid="twitterArticleRichTextView">
+        <div class="longform-unstyled">
+            <div class="public-DraftStyleDefault-block" data-offset-key="abc123">
+                This fixture simulates an X article rendered on a status URL without an inline author block.
+            </div>
+        </div>
+        <div class="longform-unstyled">
+            <div class="public-DraftStyleDefault-block" data-offset-key="def456">
+                The author should fall back to the handle embedded in the page URL.
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Fix author extraction for X article pages rendered on `/status/:id` URLs.

Previously, `XArticleExtractor#getAuthorFromUrl()` only matched `/article/:id`, so browser-based parsing could fall back to `"Unknown"` when:
- the page rendered article content,
- the inline author block was unavailable, and
- `og:title` used localized text instead of the English `"... on X: ..."` pattern.

This change expands the URL fallback to support both `/status/:id` and `/article/:id`.

## Tests

- added a fixture for an X article rendered on a localized `/status/:id` URL without an inline author block
- ran `npm test`