### PR TITLE
fix: exit with error when no content is extracted

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,6 +72,13 @@ program
 				markdown: options.markdown
 			});
 
+			// Check if parsing produced meaningful content
+			const textContent = result.content.replace(/<[^>]*>/g, '').trim();
+			if (!textContent) {
+				console.error(ansi.red(`Error: No content could be extracted from ${source}`));
+				process.exit(1);
+			}
+
 			// Format output
 			let output: string;
 


### PR DESCRIPTION
## Summary

- CLI now exits with code 1 and prints an error message when no meaningful content can be extracted from a source
- Previously, parsing failures (binary files, Cloudflare-blocked pages, empty documents) produced empty output with exit code 0 (silent failure)
- The check strips HTML tags from `result.content` and verifies non-empty text remains before proceeding to output

## Motivation

When using defuddle CLI in scripts or automation, silent failures with exit code 0 make it impossible to detect parsing errors. This is especially problematic for:
- Binary file URLs (tarballs, images) — empty output, no error
- Cloudflare-protected pages — empty output, no error
- Any page where content extraction yields nothing

## Test plan

- [x] `defuddle parse binary.tar.gz` → exits 1 with error message
- [x] `defuddle parse valid-article.html` → exits 0 with content (no regression)
- [x] Empty HTML document → exits 1 with error message