### PR TITLE
fix: handle invalid URL in YouTube getVideoId()

### DIFF
--- a/src/extractors/youtube.ts
+++ b/src/extractors/youtube.ts
@@ -608,11 +608,15 @@ export class YoutubeExtractor extends BaseExtractor {
 	}
 
 	private getVideoId(): string {
-		const url = new URL(this.url);
-		if (url.hostname === 'youtu.be') {
-			return url.pathname.slice(1);
+		try {
+			const url = new URL(this.url);
+			if (url.hostname === 'youtu.be') {
+				return url.pathname.slice(1);
+			}
+			return new URLSearchParams(url.search).get('v') || '';
+		} catch {
+			return '';
 		}
-		return new URLSearchParams(url.search).get('v') || '';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Added try-catch around `new URL(this.url)` in `getVideoId()` to prevent `TypeError: Invalid URL` when `this.url` is undefined or malformed
- Returns empty string on failure instead of throwing, consistent with the existing `|| ''` fallback

## Motivation

When the YouTube extractor receives an undefined or invalid URL, `new URL(this.url)` throws an unhandled `TypeError: Invalid URL (input: 'undefined')` to stderr. This happens for certain YouTube videos where the URL isn't properly passed through the extractor pipeline.

Note: PR #51 fixed a related but different issue (youtu.be short URL parsing). This fix addresses the case where `this.url` itself is undefined/invalid, which still occurs in v0.13.0.

## Test plan

- [x] YouTube video with valid URL → works as before
- [x] YouTube extractor with undefined URL → returns empty string, no TypeError