### PR TITLE
fix: remove <wbr> tags to prevent unwanted spaces in markdown

### DIFF
--- a/src/defuddle.ts
+++ b/src/defuddle.ts
@@ -570,6 +570,10 @@ export class Defuddle {
 				};
 			}
 
+			// Remove <wbr> elements — word break opportunity hints that carry no
+			// content but cause unwanted whitespace during standardization.
+			mainContent.querySelectorAll('wbr').forEach(el => el.remove());
+
 			// Standardize footnotes before cleanup (CSS sidenotes use display:none)
 			if (options.standardize) {
 				standardizeFootnotes(mainContent);

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -692,6 +692,11 @@ export function createMarkdownContent(content: string, url: string) {
 	}
 
 	try {
+		// Remove <wbr> tags before conversion — wbr is a word break opportunity
+		// hint, not actual content, and Turndown's void element whitespace
+		// preservation would otherwise insert unwanted spaces.
+		content = content.replace(/<wbr\s*\/?>/gi, '');
+
 		let markdown = turndownService.turndown(content);
 
 		// Remove the title from the beginning of the content if it exists

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -36,4 +36,20 @@ describe('Markdown conversion', () => {
 			expect(result.contentMarkdown).toContain('Hello! This is great!');
 		});
 	});
+
+	describe('wbr tag handling', () => {
+		test('should remove wbr tags without adding any content', async () => {
+			const html = `<html><head><title>Test</title></head><body><article><p>Super<wbr>cali<wbr>fragilistic</p></article></body></html>`;
+			const result = await Defuddle(parseDocument(html, 'https://example.com'), 'https://example.com', { separateMarkdown: true });
+
+			expect(result.contentMarkdown).toContain('Supercalifragilistic');
+		});
+
+		test('should handle wbr in links', async () => {
+			const html = `<html><head><title>Test</title></head><body><article><p><a href="https://example.com">long<wbr>word</a></p></article></body></html>`;
+			const result = await Defuddle(parseDocument(html, 'https://example.com'), 'https://example.com', { separateMarkdown: true });
+
+			expect(result.contentMarkdown).toContain('longword');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- Remove `<wbr>` (word break opportunity) elements at two levels to prevent unwanted space insertion in markdown output:
  - **DOM level**: strip `<wbr>` elements before standardization runs, preventing whitespace from being baked into the content during processing
  - **Markdown level**: regex safety net before Turndown conversion for content that may bypass DOM-level removal
- Added 2 test cases for wbr handling

## Motivation

Sites like docs.rs insert `<wbr>` tags for long identifiers (e.g., `MTL<wbr>Acceleration<wbr>Structure`). The `<wbr>` tag is a word break *opportunity* hint — browsers render it with zero width (no visible space). However, defuddle's standardization step adds whitespace around inline void elements, turning `MTLAccelerationStructure` into `MTL  Acceleration  Structure`.

## Test plan

- [x] `Super<wbr>cali<wbr>fragilistic` → `Supercalifragilistic` (no spaces)
- [x] `<a>long<wbr>word</a>` → `longword` (no spaces inside links)
- [x] Existing tests pass (no regression)