### PR TITLE
Add image download, config file support, and CLI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,40 @@ npx defuddle parse page.html --debug
 | `--property <name>` | `-p` | Extract a specific property (e.g., title, description, domain) |
 | `--debug` | | Enable debug mode |
 | `--lang <code>` | `-l` | Preferred language (BCP 47, e.g. `en`, `fr`, `ja`) |
+| `--download-images` | | Download remote images referenced in generated markdown and rewrite links |
+| `--image-dir <dir>` | | Local image folder relative to output markdown (default: `attachments`) |
+| `--image-dir-from-output` | | Save images in a folder using output markdown base name (e.g. `article`) |
+
+#### CLI default options file
+
+Defuddle looks for a config file in the current working directory (checked in order):
+- `defuddle.config.json`
+- `.defuddlerc`
+- `.defuddlerc.json`
+
+The config file is only loaded when **no CLI flags are passed**. If any flag is present on the command line, the config file is ignored entirely and you must supply all options manually.
+
+The config file should be JSON with the same option keys (e.g. `markdown`, `output`, `downloadImages`, `imageDir`, `imageDirFromOutput`, `lang`). When `downloadImages` is set without `output`, the output filename is auto-generated from the URL (e.g. `stephango.com-saw.md`). Example `defuddle.config.json`:
+
+```json
+{
+  "markdown": true,
+  "downloadImages": true,
+  "imageDir": "attachments"
+}
+```
+
+With this config, running `npx defuddle parse <url>` will save clean markdown to a file named after the URL in the current directory, with images downloaded to an `attachments/` subfolder.
+
+For an output-named image folder, use:
+
+```json
+{
+  "markdown": true,
+  "downloadImages": true,
+  "imageDirFromOutput": true
+}
+```
 
 ## Installation
 

--- a/defuddle.config.json
+++ b/defuddle.config.json
@@ -1,0 +1,5 @@
+{
+  "markdown": true,
+  "downloadImages": true,
+  "imageDir": "attachments"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -169,7 +168,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1434,7 +1432,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1470,7 +1467,6 @@
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -1603,7 +1599,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2726,7 +2721,6 @@
 			"integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssstyle": "^4.0.1",
 				"data-urls": "^5.0.0",
@@ -3556,7 +3550,6 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
 			"integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.8.2",
@@ -3666,7 +3659,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3792,7 +3784,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
 			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3870,7 +3861,6 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -3987,7 +3977,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -4149,7 +4138,6 @@
 			"integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -4198,7 +4186,6 @@
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,8 @@
 
 import { Command } from 'commander';
 import { Defuddle } from './node';
-import { writeFile, readFile } from 'fs/promises';
-import { resolve } from 'path';
+import { writeFile, readFile, mkdir, access } from 'fs/promises';
+import { resolve, dirname, basename, extname, relative } from 'path';
 import { parseLinkedomHTML } from './utils/linkedom-compat';
 import { countWords } from './utils';
 import { getInitialUA, fetchPage, extractRawMarkdown, cleanMarkdownContent, BOT_UA } from './fetch';
@@ -13,6 +13,9 @@ interface ParseOptions {
 	markdown?: boolean;
 	md?: boolean;
 	json?: boolean;
+	downloadImages?: boolean;
+	imageDir?: string;
+	imageDirFromOutput?: boolean;
 	debug?: boolean;
 	property?: string;
 	lang?: string;
@@ -24,6 +27,171 @@ const ansi = {
 	red: (s: string) => useColor ? `\x1b[31m${s}\x1b[39m` : s,
 	green: (s: string) => useColor ? `\x1b[32m${s}\x1b[39m` : s,
 };
+
+const IMAGE_MARKDOWN_RE = /!\[([^\]]*)\]\(\s*<?([^>\s]+)>?(?:\s+(["'][^"']*["']))?\s*\)/g;
+
+const CLI_CONFIG_FILES = ['defuddle.config.json', '.defuddlerc', '.defuddlerc.json'];
+
+async function loadDefaultCliOptions(): Promise<Partial<ParseOptions>> {
+	for (const fileName of CLI_CONFIG_FILES) {
+		const configPath = resolve(process.cwd(), fileName);
+		try {
+			const content = await readFile(configPath, 'utf-8');
+			const parsed = JSON.parse(content);
+			if (typeof parsed === 'object' && parsed !== null) {
+				return parsed as Partial<ParseOptions>;
+			}
+		} catch {
+			// ignore missing/invalid config
+		}
+	}
+	return {};
+}
+
+function hasManualCliFlags(argv: string[]): boolean {
+	// If user passed any flag (e.g. --markdown, -o), treat as manual override.
+	return argv.slice(2).some(arg => arg.startsWith('-'));
+}
+
+function sanitizeFileName(raw: string): string {
+	return raw
+		.trim()
+		.normalize('NFKC')
+		.replace(/[\/:*?"<>|]+/g, '-')
+		.replace(/[^a-zA-Z0-9._-]+/g, '-')
+		.replace(/^-+|[-]+$/g, '')
+		|| 'image';
+}
+
+function getPageName(url?: string, outputPath?: string): string {
+	if (url) {
+		try {
+			const parsed = new URL(url);
+			let name = parsed.hostname;
+			const lastSegment = basename(parsed.pathname);
+			if (lastSegment && lastSegment !== '/') {
+				name = `${parsed.hostname}-${lastSegment}`;
+			}
+			name = sanitizeFileName(name);
+			return name || 'homepage';
+		} catch {
+			// fall through
+		}
+	}
+	if (outputPath) {
+		const outBase = basename(outputPath, extname(outputPath));
+		return sanitizeFileName(outBase) || 'page';
+	}
+	return 'homepage';
+}
+
+function extensionFromContentType(contentType?: string): string {
+	if (!contentType) return '.jpg';
+	if (contentType.includes('png')) return '.png';
+	if (contentType.includes('gif')) return '.gif';
+	if (contentType.includes('webp')) return '.webp';
+	if (contentType.includes('svg')) return '.svg';
+	if (contentType.includes('jpeg')) return '.jpg';
+	if (contentType.includes('bmp')) return '.bmp';
+	if (contentType.includes('avif')) return '.avif';
+	return '.jpg';
+}
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function downloadImagesInMarkdown(markdown: string, outputPath: string, imageDir: string, baseUrl: string | undefined, pageName: string): Promise<string> {
+	const outputDir = dirname(outputPath);
+	const saveDir = resolve(outputDir, imageDir || 'attachments');
+	await mkdir(saveDir, { recursive: true });
+
+	const urlToLocal = new Map<string, string>();
+	let imageIndex = 0;
+	let result = '';
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+	IMAGE_MARKDOWN_RE.lastIndex = 0;
+
+	while ((match = IMAGE_MARKDOWN_RE.exec(markdown)) !== null) {
+		const [fullMatch, altText, rawUrl, titlePart] = match;
+		const matchStart = match.index;
+		const matchEnd = IMAGE_MARKDOWN_RE.lastIndex;
+		result += markdown.slice(lastIndex, matchStart);
+		lastIndex = matchEnd;
+
+		let imageUrl = rawUrl;
+		if (imageUrl.startsWith('//')) {
+			imageUrl = 'https:' + imageUrl;
+		}
+		if (!imageUrl.startsWith('http://') && !imageUrl.startsWith('https://') && baseUrl) {
+			try {
+				imageUrl = new URL(imageUrl, baseUrl).toString();
+			} catch {
+				// leave as-is
+			}
+		}
+
+		const isRemote = imageUrl.startsWith('http://') || imageUrl.startsWith('https://');
+		if (!isRemote || imageUrl.startsWith('data:')) {
+			result += fullMatch;
+			continue;
+		}
+
+		let localPath = urlToLocal.get(imageUrl);
+		if (!localPath) {
+			try {
+				const response = await fetch(imageUrl, { method: 'GET' });
+				if (!response.ok) {
+					result += fullMatch;
+					continue;
+				}
+
+				const finalUrl = response.url || imageUrl;
+				let ext = extname(new URL(finalUrl).pathname);
+				if (!ext) {
+					ext = extensionFromContentType(response.headers.get('content-type') || undefined);
+				}
+
+				let candidateName = `${pageName}-${imageIndex}${ext || '.jpg'}`;
+				candidateName = sanitizeFileName(candidateName);
+				if (!extname(candidateName)) {
+					candidateName += ext || '.jpg';
+				}
+
+				let destination = resolve(saveDir, candidateName);
+				let collision = 1;
+				while (await fileExists(destination)) {
+					candidateName = `${pageName}-${imageIndex}-${collision}${ext || '.jpg'}`;
+					candidateName = sanitizeFileName(candidateName);
+					destination = resolve(saveDir, candidateName);
+					collision += 1;
+				}
+
+				const data = Buffer.from(await response.arrayBuffer());
+				await writeFile(destination, data);
+
+				localPath = relative(outputDir, destination).replace(/\\/g, '/');
+				urlToLocal.set(imageUrl, localPath);
+				imageIndex += 1;
+			} catch {
+				result += fullMatch;
+				continue;
+			}
+		}
+
+		const linkTitle = titlePart ? ` ${titlePart}` : '';
+		result += `![${altText}](${localPath}${linkTitle})`;
+	}
+
+	result += markdown.slice(lastIndex);
+	return result;
+}
 
 // Read version from package.json
 const version = require('../package.json').version;
@@ -43,6 +211,9 @@ program
 	.option('-m, --markdown', 'Convert content to markdown format')
 	.option('--md', 'Alias for --markdown')
 	.option('-j, --json', 'Output as JSON with metadata and content')
+	.option('--download-images', 'Download linked images inside markdown and rewrite markup to local paths')
+	.option('--image-dir <dir>', 'Local image directory relative to output markdown file (default: attachments)')
+	.option('--image-dir-from-output', 'Save images in a folder named after the output markdown file base name')
 	.option('-p, --property <name>', 'Extract a specific property (e.g., title, description, domain)')
 	.option('--debug', 'Enable debug mode')
 	.option('-l, --lang <code>', 'Preferred language (BCP 47, e.g. en, fr, ja)')
@@ -51,6 +222,15 @@ program
 			// Handle --md alias
 			if (options.md) {
 				options.markdown = true;
+			}
+
+			// Load default CLI options from configuration file if user did not provide manual flags.
+			if (!hasManualCliFlags(process.argv)) {
+				const defaults = await loadDefaultCliOptions();
+				options = {
+					...defaults,
+					...options,
+				};
 			}
 
 			const defuddleOpts = {
@@ -145,7 +325,26 @@ program
 			}
 
 			// Handle output
-			if (options.output) {
+			if (options.downloadImages && !options.markdown) {
+				console.error(ansi.red('Error: --download-images can only be used with --markdown')); 
+				process.exit(1);
+			}
+
+			if (options.downloadImages) {
+				if (!options.output) {
+					// Auto-generate output filename from URL or source when not specified
+					const autoName = getPageName(url, source) + '.md';
+					options.output = autoName;
+				}
+				const outputPath = resolve(process.cwd(), options.output);
+				const imageDir = options.imageDirFromOutput
+					? basename(outputPath, extname(outputPath))
+					: options.imageDir || 'attachments';
+				const pageName = getPageName(url, outputPath);
+				output = await downloadImagesInMarkdown(output, outputPath, imageDir, url, pageName);
+				await writeFile(outputPath, output, 'utf-8');
+				console.log(ansi.green(`Output written to ${options.output}`));
+			} else if (options.output) {
 				const outputPath = resolve(process.cwd(), options.output);
 				await writeFile(outputPath, output, 'utf-8');
 				console.log(ansi.green(`Output written to ${options.output}`));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,6 +106,62 @@ async function fileExists(path: string): Promise<boolean> {
 	}
 }
 
+const MIN_IMAGE_BYTES = 1024;
+const FETCH_RETRY_COUNT = 3;
+const FETCH_RETRY_DELAY_MS = 1500;
+
+async function fetchImageWithRetry(imageUrl: string): Promise<{ data: Buffer; ext: string } | null> {
+	let referer = '';
+	try { referer = new URL(imageUrl).origin; } catch { /* ignore */ }
+
+	const headers: Record<string, string> = {
+		'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+	};
+	if (referer) headers['Referer'] = referer;
+
+	for (let attempt = 1; attempt <= FETCH_RETRY_COUNT; attempt++) {
+		try {
+			const response = await fetch(imageUrl, { method: 'GET', headers });
+
+			// 4xx: server explicitly rejected — no point retrying
+			if (response.status >= 400 && response.status < 500) {
+				return null;
+			}
+
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}`);
+			}
+
+			// Validate Content-Type: skip non-image responses (e.g. HTML error pages)
+			const contentType = response.headers.get('content-type') || '';
+			const isImage = contentType.startsWith('image/');
+			const isBinary = contentType.includes('application/octet-stream') || contentType === '';
+			if (!isImage && !isBinary) {
+				return null;
+			}
+
+			const arrayBuffer = await response.arrayBuffer();
+
+			// Skip tracking pixels (< 1 KB)
+			if (arrayBuffer.byteLength < MIN_IMAGE_BYTES) {
+				return null;
+			}
+
+			const finalUrl = response.url || imageUrl;
+			let ext = extname(new URL(finalUrl).pathname);
+			if (!ext) {
+				ext = extensionFromContentType(contentType || undefined);
+			}
+
+			return { data: Buffer.from(arrayBuffer), ext };
+		} catch (err) {
+			if (attempt === FETCH_RETRY_COUNT) return null;
+			await new Promise(r => setTimeout(r, FETCH_RETRY_DELAY_MS));
+		}
+	}
+	return null;
+}
+
 async function downloadImagesInMarkdown(markdown: string, outputPath: string, imageDir: string, baseUrl: string | undefined, pageName: string): Promise<string> {
 	const outputDir = dirname(outputPath);
 	const saveDir = resolve(outputDir, imageDir || 'attachments');
@@ -145,44 +201,38 @@ async function downloadImagesInMarkdown(markdown: string, outputPath: string, im
 
 		let localPath = urlToLocal.get(imageUrl);
 		if (!localPath) {
-			try {
-				const response = await fetch(imageUrl, { method: 'GET' });
-				if (!response.ok) {
-					result += fullMatch;
-					continue;
-				}
+			const fetched = await fetchImageWithRetry(imageUrl);
+			if (!fetched) {
+				result += fullMatch;
+				continue;
+			}
 
-				const finalUrl = response.url || imageUrl;
-				let ext = extname(new URL(finalUrl).pathname);
-				if (!ext) {
-					ext = extensionFromContentType(response.headers.get('content-type') || undefined);
-				}
+			const { data, ext } = fetched;
+			let candidateName = `${pageName}-${imageIndex}${ext || '.jpg'}`;
+			candidateName = sanitizeFileName(candidateName);
+			if (!extname(candidateName)) {
+				candidateName += ext || '.jpg';
+			}
 
-				let candidateName = `${pageName}-${imageIndex}${ext || '.jpg'}`;
+			let destination = resolve(saveDir, candidateName);
+			let collision = 1;
+			while (await fileExists(destination)) {
+				candidateName = `${pageName}-${imageIndex}-${collision}${ext || '.jpg'}`;
 				candidateName = sanitizeFileName(candidateName);
-				if (!extname(candidateName)) {
-					candidateName += ext || '.jpg';
-				}
+				destination = resolve(saveDir, candidateName);
+				collision += 1;
+			}
 
-				let destination = resolve(saveDir, candidateName);
-				let collision = 1;
-				while (await fileExists(destination)) {
-					candidateName = `${pageName}-${imageIndex}-${collision}${ext || '.jpg'}`;
-					candidateName = sanitizeFileName(candidateName);
-					destination = resolve(saveDir, candidateName);
-					collision += 1;
-				}
-
-				const data = Buffer.from(await response.arrayBuffer());
+			try {
 				await writeFile(destination, data);
-
-				localPath = relative(outputDir, destination).replace(/\\/g, '/');
-				urlToLocal.set(imageUrl, localPath);
-				imageIndex += 1;
 			} catch {
 				result += fullMatch;
 				continue;
 			}
+
+			localPath = relative(outputDir, destination).replace(/\\/g, '/');
+			urlToLocal.set(imageUrl, localPath);
+			imageIndex += 1;
 		}
 
 		const linkTitle = titlePart ? ` ${titlePart}` : '';


### PR DESCRIPTION
Add --download-images flag to download remote images in markdown and rewrite links to local paths
Add --image-dir and --image-dir-from-output options to control image save location (default: attachments/)
Auto-generate output filename from URL when --download-images is set without --output
Add defuddle.config.json / .defuddlerc config file support for default CLI options (loaded when no manual flags are passed)
Update README with new options and config file documentation