### PR TITLE
fix: updated defuddle.ts to use proper description

### DIFF
--- a/src/defuddle.ts
+++ b/src/defuddle.ts
@@ -1257,7 +1257,7 @@ export class Defuddle {
 		return {
 			content: contentHtml,
 			title: extracted.variables?.title || metadata.title,
-			description: metadata.description,
+			description: extracted.variables?.description || metadata.description,
 			domain: metadata.domain,
 			favicon: metadata.favicon,
 			image: metadata.image,


### PR DESCRIPTION
#174 has been closed but `description` retrieved by `defuddle.ts` is still fetched from stale data.
Updated `defuddle.ts` to use updated description.