### PR TITLE
YouTube: respect preferred transcript language

### DIFF
--- a/src/extractors/youtube.ts
+++ b/src/extractors/youtube.ts
@@ -31,7 +31,7 @@ const INNERTUBE_WEB_CONTEXT = {
 	}
 };
 
-type TranscriptResult = { html: string; text: string; languageCode: string };
+type TranscriptResult = { html: string; text: string; languageCode?: string };
 
 interface TranscriptSelectors {
 	segments: string;
@@ -101,12 +101,18 @@ export class YoutubeExtractor extends BaseExtractor {
 		return this.normalizeLanguageCode(languageCode).split('-')[0] || '';
 	}
 
-	private languageCodeMatchesPreference(languageCode?: string, preferredLang?: string): boolean {
+	private isExactLanguageCodeMatch(languageCode?: string, preferredLang?: string): boolean {
 		const normalizedLanguageCode = this.normalizeLanguageCode(languageCode);
 		const normalizedPreferredLang = this.normalizeLanguageCode(preferredLang);
 		if (!normalizedLanguageCode || !normalizedPreferredLang) return false;
-		if (normalizedLanguageCode === normalizedPreferredLang) return true;
+		return normalizedLanguageCode === normalizedPreferredLang;
+	}
 
+	private languageCodeMatchesPreference(languageCode?: string, preferredLang?: string): boolean {
+		if (this.isExactLanguageCodeMatch(languageCode, preferredLang)) return true;
+
+		const normalizedLanguageCode = this.normalizeLanguageCode(languageCode);
+		const normalizedPreferredLang = this.normalizeLanguageCode(preferredLang);
 		const baseLanguageCode = this.getBaseLanguageCode(normalizedLanguageCode);
 		const basePreferredLang = this.getBaseLanguageCode(normalizedPreferredLang);
 		if (!baseLanguageCode || baseLanguageCode !== basePreferredLang) return false;
@@ -125,12 +131,30 @@ export class YoutubeExtractor extends BaseExtractor {
 		return Array.isArray(captionTracks) ? captionTracks : [];
 	}
 
+	private findPreferredCaptionTrack(captionTracks: any[], preferredLang?: string): any | undefined {
+		const exactMatch = captionTracks.find((track: any) =>
+			this.isExactLanguageCodeMatch(track.languageCode, preferredLang)
+		);
+		if (exactMatch) return exactMatch;
+
+		const normalizedPreferredLang = this.normalizeLanguageCode(preferredLang);
+		const basePreferredLang = this.getBaseLanguageCode(normalizedPreferredLang);
+		if (!basePreferredLang) return undefined;
+
+		const baseLanguageMatch = captionTracks.find((track: any) =>
+			this.normalizeLanguageCode(track.languageCode) === basePreferredLang
+		);
+		if (baseLanguageMatch) return baseLanguageMatch;
+
+		return captionTracks.find((track: any) =>
+			this.getBaseLanguageCode(track.languageCode) === basePreferredLang
+		);
+	}
+
 	private pickCaptionTrack(captionTracks: any[]): any | undefined {
 		const preferredLang = this.options.language;
 		if (preferredLang) {
-			const match = captionTracks.find((track: any) =>
-				this.languageCodeMatchesPreference(track.languageCode, preferredLang)
-			);
+			const match = this.findPreferredCaptionTrack(captionTracks, preferredLang);
 			if (match) return match;
 		}
 		return captionTracks.find((track: any) => track.languageCode === 'en') || captionTracks[0];
@@ -150,16 +174,16 @@ export class YoutubeExtractor extends BaseExtractor {
 			.toLocaleLowerCase();
 	}
 
-	private getTranscriptLanguageCodeFromDom(): string {
+	private getTranscriptLanguageCodeFromDom(): string | undefined {
 		const langButton = this.document.querySelector(
 			'ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-searchable-transcript"] #footer yt-sort-filter-sub-menu-renderer yt-dropdown-menu button'
 		);
 		const selectedLabel = langButton?.textContent?.trim();
 		const captionTracks = this.getCaptionTracks(this.getValidatedPlayerResponse());
-		const preferredTrack = this.pickCaptionTrack(captionTracks);
+		const onlyTrack = captionTracks.length === 1 ? captionTracks[0] : undefined;
 
 		if (!selectedLabel) {
-			return preferredTrack?.languageCode || 'en';
+			return onlyTrack?.languageCode;
 		}
 
 		const normalizedSelectedLabel = this.normalizeLanguageLabel(selectedLabel);
@@ -167,7 +191,7 @@ export class YoutubeExtractor extends BaseExtractor {
 			this.normalizeLanguageLabel(this.getTrackDisplayName(track)) === normalizedSelectedLabel
 		);
 
-		return matchingTrack?.languageCode || preferredTrack?.languageCode || 'en';
+		return matchingTrack?.languageCode || onlyTrack?.languageCode;
 	}
 
 	private getInlineChapters(): { title: string; start: number }[] {

--- a/tests/youtube-transcript.test.ts
+++ b/tests/youtube-transcript.test.ts
@@ -36,6 +36,19 @@ function getTranscriptPanelHtml() {
 	`;
 }
 
+function getTranscriptPanelHtmlWithoutLanguageButton() {
+	return `
+		<ytd-engagement-panel-section-list-renderer target-id="engagement-panel-searchable-transcript">
+			<div id="segments-container">
+				<ytd-transcript-segment-renderer>
+					<div class="segment-timestamp">0:00</div>
+					<div class="segment-text">Hello world.</div>
+				</ytd-transcript-segment-renderer>
+			</div>
+		</ytd-engagement-panel-section-list-renderer>
+	`;
+}
+
 describe('YouTube transcript parsing', () => {
 	test('parses srv3 format (<p>/<s> elements)', () => {
 		const extractor = createExtractor();
@@ -231,9 +244,10 @@ describe('YouTube transcript parsing', () => {
 		const extractor = createExtractor(`
 			<html>
 				<body>
-					<script>
-						var ytInitialPlayerResponse = {
-							"captions": {
+						<script>
+							var ytInitialPlayerResponse = {
+								"videoDetails": { "videoId": "test123" },
+								"captions": {
 								"playerCaptionsTracklistRenderer": {
 									"captionTracks": [
 										{
@@ -268,9 +282,10 @@ describe('YouTube transcript parsing', () => {
 		const extractor = createExtractor(`
 			<html>
 				<body>
-					<script>
-						var ytInitialPlayerResponse = {
-							"captions": {
+						<script>
+							var ytInitialPlayerResponse = {
+								"videoDetails": { "videoId": "test123" },
+								"captions": {
 								"playerCaptionsTracklistRenderer": {
 									"captionTracks": [
 										{
@@ -319,9 +334,10 @@ describe('YouTube transcript parsing', () => {
 		const extractor = createExtractor(`
 			<html>
 				<body>
-					<script>
-						var ytInitialPlayerResponse = {
-							"captions": {
+						<script>
+							var ytInitialPlayerResponse = {
+								"videoDetails": { "videoId": "test123" },
+								"captions": {
 								"playerCaptionsTracklistRenderer": {
 									"captionTracks": [
 										{
@@ -359,9 +375,10 @@ describe('YouTube transcript parsing', () => {
 		const extractor = createExtractor(`
 			<html>
 				<body>
-					<script>
-						var ytInitialPlayerResponse = {
-							"captions": {
+						<script>
+							var ytInitialPlayerResponse = {
+								"videoDetails": { "videoId": "test123" },
+								"captions": {
 								"playerCaptionsTracklistRenderer": {
 									"captionTracks": [
 										{
@@ -402,12 +419,67 @@ describe('YouTube transcript parsing', () => {
 		expect(clickSpy).not.toHaveBeenCalled();
 	});
 
+	test('extractAsync does not trust DOM transcript language when no selector is present and multiple tracks exist', async () => {
+		const extractor = createExtractor(`
+			<html>
+				<body>
+						<script>
+							var ytInitialPlayerResponse = {
+								"videoDetails": { "videoId": "test123" },
+								"captions": {
+								"playerCaptionsTracklistRenderer": {
+									"captionTracks": [
+										{
+											"languageCode": "en",
+											"name": { "simpleText": "English (auto-generated)" }
+										},
+										{
+											"languageCode": "zh",
+											"name": { "simpleText": "中文" }
+										}
+									]
+								}
+							}
+						};
+					</script>
+					<ytd-video-description-transcript-section-renderer>
+						<button id="open-transcript">Show transcript</button>
+					</ytd-video-description-transcript-section-renderer>
+					${getTranscriptPanelHtmlWithoutLanguageButton()}
+				</body>
+			</html>
+		`, 'https://www.youtube.com/watch?v=test123', { language: 'zh' });
+
+		(extractor as any).fetchTranscript = vi.fn().mockResolvedValue({
+			html: '<div class="youtube transcript"><h2>Transcript</h2><p class="transcript-segment"><strong><span class="timestamp" data-timestamp="0">0:00</span></strong> · 你好，世界。</p></div>',
+			text: '**0:00** · 你好，世界。',
+			languageCode: 'zh',
+		});
+
+		const result = await extractor.extractAsync();
+
+		expect(result.variables.language).toBe('zh');
+		expect(result.variables.transcript).toContain('**0:00** · 你好，世界。');
+		expect((extractor as any).fetchTranscript).toHaveBeenCalledTimes(1);
+	});
+
 	test('pickCaptionTrack falls back from regional language tags to base language tracks', () => {
 		const extractor = createExtractor(undefined, undefined, { language: 'zh-CN' });
 		const track = (extractor as any).pickCaptionTrack([
 			{ languageCode: 'en' },
 			{ languageCode: 'zh' },
 			{ languageCode: 'zh-Hant' },
+		]);
+
+		expect(track?.languageCode).toBe('zh');
+	});
+
+	test('pickCaptionTrack prefers an exact base-language track over earlier regional variants', () => {
+		const extractor = createExtractor(undefined, undefined, { language: 'zh' });
+		const track = (extractor as any).pickCaptionTrack([
+			{ languageCode: 'zh-Hant' },
+			{ languageCode: 'zh' },
+			{ languageCode: 'en' },
 		]);
 
 		expect(track?.languageCode).toBe('zh');
@@ -445,9 +517,10 @@ describe('YouTube transcript parsing', () => {
 		const extractor = createExtractor(`
 			<html>
 				<body>
-					<script>
-						var ytInitialPlayerResponse = {
-							"captions": {
+						<script>
+							var ytInitialPlayerResponse = {
+								"videoDetails": { "videoId": "test123" },
+								"captions": {
 								"playerCaptionsTracklistRenderer": {
 									"captionTracks": [
 										{
@@ -497,9 +570,10 @@ describe('YouTube transcript parsing', () => {
 		const mobileHtml = `
 			<html>
 				<body>
-					<script>
-						var ytInitialPlayerResponse = {
-							"captions": {
+						<script>
+							var ytInitialPlayerResponse = {
+								"videoDetails": { "videoId": "test123" },
+								"captions": {
 								"playerCaptionsTracklistRenderer": {
 									"captionTracks": [
 										{


### PR DESCRIPTION
## Summary
- pass extractor options through `YoutubeExtractor` so `language` reaches transcript selection
- avoid short-circuiting on an existing DOM transcript when it does not match the requested language
- fall back from regional tags like `zh-CN` to base tracks like `zh`
- add regression tests for DOM short-circuiting and regional language fallback

## Repro
```bash
npx defuddle parse "https://www.youtube.com/watch?v=P-NmMX9rlYQ" --lang zh
npx defuddle parse "https://www.youtube.com/watch?v=P-NmMX9rlYQ" --lang zh-CN
```
Both commands previously returned the English transcript even though Chinese tracks were available.

## Testing
- `npm test -- tests/youtube-transcript.test.ts`
- `npm test`