### PR TITLE
Fix Reddit author extraction when comments haven't loaded

### DIFF
--- a/src/extractors/reddit.ts
+++ b/src/extractors/reddit.ts
@@ -64,7 +64,27 @@ export class RedditExtractor extends BaseExtractor {
 		// old.reddit.com with full content.
 		const hasComments = this.document.querySelectorAll('shreddit-comment').length > 0;
 		if (this.isCommentsPage() && !hasComments) {
-			return { content: '', contentHtml: '' };
+			const postTitle = this.document.querySelector('h1')?.textContent?.trim() || '';
+			const subreddit = this.getSubreddit();
+			const postAuthor = this.getPostAuthor();
+			const postContent = this.getPostContent();
+			const description = this.createDescription(postContent);
+
+			return {
+				content: '',
+				contentHtml: '',
+				extractedContent: {
+					postId: this.getPostId(),
+					subreddit,
+					postAuthor,
+				},
+				variables: {
+					title: postTitle,
+					author: postAuthor,
+					site: `r/${subreddit}`,
+					description,
+				}
+			};
 		}
 
 		const postContent = this.getPostContent();

--- a/tests/reddit-author.test.ts
+++ b/tests/reddit-author.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from 'vitest';
+import Defuddle from '../src/index';
+import { parseDocument } from './helpers';
+
+/**
+ * Regression test for Reddit author extraction.
+ *
+ * When a new-Reddit comments page has a <shreddit-post> element but no
+ * <shreddit-comment> elements (lazy-loaded), the extractor's sync path
+ * returns early. Previously this early return omitted `variables.author`,
+ * causing fallback to the generic MetadataExtractor which picked up
+ * multiple usernames from the DOM (.author class elements, logged-in user
+ * badges, etc.), producing a comma-separated list instead of just the
+ * original poster.
+ */
+
+const REDDIT_URL = 'https://www.reddit.com/r/test/comments/abc123/test_post/';
+
+const NEW_REDDIT_NO_COMMENTS_HTML = `
+<html>
+<head>
+<title>Test Post : test</title>
+</head>
+<body>
+<h1>Test Post Title</h1>
+<shreddit-post
+  author="original_poster"
+  subreddit-prefixed-name="r/test"
+  post-title="Test Post Title"
+  score="42"
+  comment-count="5"
+  created-timestamp="2025-01-15T10:00:00Z"
+  permalink="/r/test/comments/abc123/test_post/">
+  <div slot="text-body"><p>This is the post body content.</p></div>
+</shreddit-post>
+<!-- No shreddit-comment elements: they haven't loaded yet -->
+<span class="author">logged_in_user</span>
+<span class="author">some_commenter</span>
+</body>
+</html>
+`;
+
+const NEW_REDDIT_WITH_COMMENTS_HTML = `
+<html>
+<head>
+<title>Test Post : test</title>
+</head>
+<body>
+<h1>Test Post Title</h1>
+<shreddit-post
+  author="original_poster"
+  subreddit-prefixed-name="r/test"
+  post-title="Test Post Title"
+  score="42"
+  comment-count="5"
+  created-timestamp="2025-01-15T10:00:00Z"
+  permalink="/r/test/comments/abc123/test_post/">
+  <div slot="text-body"><p>This is the post body content.</p></div>
+</shreddit-post>
+<shreddit-comment author="commenter_one" depth="0" score="10"
+  permalink="/r/test/comments/abc123/test_post/c1/"
+  created="2025-01-15T11:00:00Z">
+  <div slot="comment"><p>Nice post!</p></div>
+</shreddit-comment>
+<shreddit-comment author="commenter_two" depth="0" score="5"
+  permalink="/r/test/comments/abc123/test_post/c2/"
+  created="2025-01-15T12:00:00Z">
+  <div slot="comment"><p>I agree.</p></div>
+</shreddit-comment>
+<span class="author">logged_in_user</span>
+</body>
+</html>
+`;
+
+describe('Reddit author extraction', () => {
+	test('comments page without loaded comments returns only the post author', () => {
+		const doc = parseDocument(NEW_REDDIT_NO_COMMENTS_HTML, REDDIT_URL);
+		const defuddle = new Defuddle(doc, { url: REDDIT_URL });
+		const result = defuddle.parse();
+
+		expect(result.author).toBe('original_poster');
+	});
+
+	test('comments page with loaded comments returns only the post author', () => {
+		const doc = parseDocument(NEW_REDDIT_WITH_COMMENTS_HTML, REDDIT_URL);
+		const defuddle = new Defuddle(doc, { url: REDDIT_URL });
+		const result = defuddle.parse();
+
+		expect(result.author).toBe('original_poster');
+	});
+
+	test('comments page without loaded comments still populates site and title', () => {
+		const doc = parseDocument(NEW_REDDIT_NO_COMMENTS_HTML, REDDIT_URL);
+		const defuddle = new Defuddle(doc, { url: REDDIT_URL });
+		const result = defuddle.parse();
+
+		expect(result.site).toBe('r/test');
+		expect(result.title).toBe('Test Post Title');
+	});
+});


### PR DESCRIPTION
Fixes #203

## Summary

- When `shreddit-comment` elements are absent (lazy-loaded), the Reddit extractor's early return omitted `variables`, causing fallback to `MetadataExtractor.getAuthor()` which picked up multiple `.author`-classed DOM elements (logged-in user, poster, commenters) instead of just the original poster.
- Populate `variables` (author, title, site, description) and `extractedContent` from the available `shreddit-post` element on the early return path. Content remains empty to still trigger the async `old.reddit.com` fallback.
- Added regression tests for both the no-comments and with-comments scenarios.

## Test plan

- [x] Existing test suite passes (161 tests)
- [x] New `reddit-author.test.ts` tests pass — verifies author is the single poster in both lazy-loaded and fully-loaded states
- [x] Manually tested in Firefox via Obsidian Web Clipper on live Reddit posts