### PR TITLE
fix: normalize detected charset before decoding

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -121,12 +121,34 @@ function detectCharset(contentType: string, buffer: ArrayBuffer): string {
 	return 'utf-8';
 }
 
+function normalizeCharset(charset: string | undefined | null): string {
+	if (!charset) return 'utf-8';
+
+	const cleaned = String(charset)
+		.toLowerCase()
+		.trim()
+		.replace(/[;,]+$/g, '')
+		.replace(/^["']|["']$/g, '');
+
+	if (cleaned === 'utf8' || cleaned === 'utf_8') return 'utf-8';
+	if (cleaned === 'latin1') return 'latin1';
+	if (cleaned === 'iso-8859-1' || cleaned === 'windows-1252') return cleaned;
+
+	return cleaned || 'utf-8';
+}
+
 function decodeHtml(buffer: ArrayBuffer, contentType: string): string {
-	const charset = detectCharset(contentType, buffer);
+	const detected = detectCharset(contentType, buffer);
+	const charset = normalizeCharset(detected);
 	if (charset === 'windows-1252' || charset === 'iso-8859-1' || charset === 'latin1') {
 		return decodeWindows1252(buffer);
 	}
-	return new TextDecoder(charset).decode(buffer);
+
+	try {
+		return new TextDecoder(charset).decode(buffer);
+	} catch {
+		return new TextDecoder('utf-8').decode(buffer);
+	}
 }
 
 /**

--- a/tests/fetch.test.ts
+++ b/tests/fetch.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('fetch charset robustness', () => {
+	test('CLI does not crash on malformed charset values in content-type', async () => {
+		const fixturePath = join(__dirname, 'fixtures', 'general--stephango.com-buy-wisely.html');
+		const fixtureHtml = readFileSync(fixturePath, 'utf-8');
+
+		const response = new Response(fixtureHtml, {
+			headers: {
+				'content-type': 'text/html; charset=utf-8,',
+			},
+		});
+
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = async () => response as any;
+
+		try {
+			const { fetchPage } = await import('../src/fetch');
+			const html = await fetchPage('https://example.com/article', 'Mozilla/5.0');
+			expect(html).toContain('Buy wisely');
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});


### PR DESCRIPTION
## Summary
This PR makes HTML decoding more robust when a page exposes a malformed charset value such as `utf-8,`.

Currently the detected charset is passed directly to `TextDecoder`, which can throw and abort parsing. This change normalizes the detected charset before decoding and falls back to UTF-8 if decoding still fails.

## Changes
- normalize detected charset values before passing them to `TextDecoder`
- trim trailing separators like `,` / `;`
- strip wrapping quotes
- normalize common UTF-8 aliases (`utf8`, `utf_8`)
- fall back to UTF-8 if decoding still throws
- add a regression test for `content-type: text/html; charset=utf-8,`

## Why
This is a small resilience fix for malformed but otherwise decodable pages. It does not change behavior for valid charset values, but avoids a hard failure when the detected charset string is slightly malformed.

## Test
- added `tests/fetch.test.ts`
- verified the new regression test passes with `npm test -- --run tests/fetch.test.ts`
