### PR TITLE
fix: adding youtube shorts handling

### DIFF
--- a/src/extractors/youtube.ts
+++ b/src/extractors/youtube.ts
@@ -877,6 +877,8 @@ export class YoutubeExtractor extends BaseExtractor {
 			const url = new URL(this.url);
 			this._videoId = url.hostname === 'youtu.be'
 				? url.pathname.slice(1)
+				: url.pathname.includes('/shorts/')
+					? url.pathname.split('/shorts/')[1].split('/')[0]
 				: new URLSearchParams(url.search).get('v') || '';
 		}
 		return this._videoId;

--- a/website/src/convert.ts
+++ b/website/src/convert.ts
@@ -36,6 +36,7 @@ function getYouTubeVideoId(url: string): string {
 	try {
 		const u = new URL(url);
 		if (u.hostname === 'youtu.be') return u.pathname.slice(1).split('?')[0];
+		if (u.pathname.includes('/shorts/')) return u.pathname.split('/shorts/')[1].split('/')[0];
 		return u.searchParams.get('v') || '';
 	} catch { return ''; }
 }


### PR DESCRIPTION
#### Possible implementation to fix #126 

As mentioned in #126 YouTube shorts body are not properly extracted.

Added support to detect and properly extract shorts `videoId`.
As a consequence, now the `content` contains the video embed in the same format as non-short videos `![](https://www.youtube.com/watch?v={{videoId}})`, along with the short transcript.

#### Tests
All tests passed (not implemented extra test specific for shorts).
Solution tested building `defuddle`, including it in [obsidian-clipper](https://github.com/obsidianmd/obsidian-clipper), and building `obsidian-clipper`.