### PR TITLE
fix: building youtube contentHtml more reliably

### DIFF
--- a/src/extractors/youtube.ts
+++ b/src/extractors/youtube.ts
@@ -342,6 +342,8 @@ export class YoutubeExtractor extends BaseExtractor {
 		// schemaOrgData (passed in at construction) may be absent or stale after YouTube SPA
 		// navigation because YouTube removes the VideoObject ld+json block on client-side nav.
 		const scripts = Array.from(this.document.querySelectorAll('script[type="application/ld+json"]'));
+		let fallbackVideoObject: any | undefined;
+
 		for (const script of scripts) {
 			try {
 				const data = JSON.parse(script.textContent || '');
@@ -352,16 +354,26 @@ export class YoutubeExtractor extends BaseExtractor {
 					const id: string = item['@id'] || item['url'] || item['embedUrl'] || '';
 					return id.includes(videoId);
 				});
-				if (videoObject) return videoObject;
+				// If the VideoObject contains a "description" property, it is the main video metadata block. Use it directly.
+				// It contains: "@id", "name", "author", "description", "duration", "embedUrl", "uploadDate", "genre", "thumbnailUrl", and "interactionStatistic" properties.
+				if (videoObject && videoObject.description) return videoObject;
+				// If the VideoObject contains a "comment" property, it contains data related to the first comment rendered on the page.
+				// It also contains: "@id", "name", "thumbnailUrl", and "uploadDate" properties of the video.
+				// Use it as a fallback if can't find a better match.
+				if (videoObject && (videoObject.comment || !fallbackVideoObject)) fallbackVideoObject = videoObject;
+
 			} catch {
 				// ignore invalid JSON
 			}
 		}
+		
+		// If we found a VideoObject with comments but no description, return it as a fallback to at least get the title and thumbnail.
+		if (fallbackVideoObject) return fallbackVideoObject;
 
-		// Fall back to og:* meta tags. YouTube updates these after SPA navigation,
-		// so they reliably reflect the current video.
+		// Fall back to og:* meta tags. YouTube usually do not updates these after SPA navigation.
 		if (videoId) {
 			const ogUrl = this.document.querySelector('meta[property="og:url"]')?.getAttribute('content') || '';
+			// Validate that the og:url corresponds to the current video ID to avoid using stale metadata after SPA navigation.
 			if (ogUrl.includes(videoId)) {
 				return {
 					name: this.document.querySelector('meta[property="og:title"]')?.getAttribute('content') || '',


### PR DESCRIPTION
#### Improving video data extraction to build `content` more reliably. Fixes #293 

The lines:
```
	let contentHtml = `<iframe ...></iframe>${formattedDescription}`;

	if (transcript?.html) {
		contentHtml += transcript.html;
	}
```
inside `buildResult()` implies that the expected behavior is for `contentHtml` to contain also the `formattedDescription` of the video. This, right now, does not happens for some videos. Descriptions of some videos (inside the `contentHtml` body) results empty: 
```
![](https://www.youtube.com/watch?v={{videoId}})
{{transcript}}
```
instead of:
```
![](https://www.youtube.com/watch?v={{videoId}})
{{description}}
{{transcript}}
```

#### Cause
This happens because `getVideoData()` returns the first `VideoObject` matched with `script[type="application/ld+json"]` and not the best one. Usually, the first `VideoObject` matched contains information about the first comment rendered on the page (that includes some video properties, but lacks the description), for example:
```
{
    "@context": "https://schema.org",
    "@type": "VideoObject",
    "@id": "https://www.youtube.com/watch?v=cz-wqROuHIM",
    "name": "#114 First Cabin Finished",
    "thumbnailUrl": "https://i.ytimg.com/vi/cz-wqROuHIM/maxresdefault.jpg",
    "uploadDate": "2024-05-26T08:08:22-07:00",
    "comment": [
        {
            "@type": "https://schema.org/Comment",
            ...,
        }
    ]
}
```
and only later the `VideoObject` containing the main video metadata block get matched, for example:
```
{
    "@context": "https://schema.org",
    "@type": "VideoObject",
    "description": "Ollie is still here. {...}",
    "duration": "PT2354S",
    "embedUrl": "https://www.youtube.com/embed/TCHFvt4W-j8",
    "name": "#115 Start Building the Greenhouse",
    "thumbnailUrl": [
        "https://i.ytimg.com/vi/TCHFvt4W-j8/maxresdefault.jpg"
    ],
    "uploadDate": "2024-06-02T01:01:18-07:00",
    "@id": "https://www.youtube.com/watch?v=TCHFvt4W-j8",
    "interactionStatistic": [
        ...,
    ],
    "genre": "Travel & Events",
    "author": "Martijn Doolaard"
}
```

This leaves `videoData.description` empty, consequentially `const description = videoData.description || '';` empty, and the `description` is not added to the `contentHtml` body.

In `defuddle.ts` the empty `description` is later populated fetching it from the metadata:
```
description: extracted.variables?.description || metadata.description,
```

#### Fix
Improved `getVideoData()` to not return the first match but the best one, also containing the `description`.
Iterating over all the matched `VideoObjects`, storing the less promising as `fallbackVideoObject` (prioritizing the one containing the `comment` property, and all the others after that) and returning directly only if `description` is present.
The comments in the updated code of `getVideoData()` further explain the updated logic.

#### Extra
I also changed the comment:
```
// Fall back to og:* meta tags. YouTube updates these after SPA navigation,
// so they reliably reflect the current video.
```
to:
```
// Fall back to og:* meta tags. YouTube usually do not updates these after SPA navigation.
```
after verifying that the original was not correct.

#### Tests
All tests passed.
Solution tested building `defuddle` and using it in [obsidian-clipper](https://github.com/obsidianmd/obsidian-clipper).