### PR TITLE
Fix #218: Preserve text in wrapper spans during footnote fallback matching

### DIFF
--- a/src/elements/footnotes.ts
+++ b/src/elements/footnotes.ts
@@ -586,6 +586,25 @@ class FootnoteHandler {
 		return results;
 	}
 
+	replaceContainerPreservingText(container: any, footnoteRef: any): void {
+		let directText = '';
+		let hasChildElements = false;
+		for (const node of container.childNodes) {
+			if (isTextNode(node)) directText += node.textContent || '';
+			else if (isElement(node)) hasChildElements = true;
+		}
+		directText = directText.trim();
+
+		if (directText && hasChildElements) {
+			const fragment = container.ownerDocument.createDocumentFragment();
+			fragment.appendChild(container.ownerDocument.createTextNode(directText));
+			fragment.appendChild(footnoteRef);
+			container.replaceWith(fragment);
+		} else {
+			container.replaceWith(footnoteRef);
+		}
+	}
+
 	findOuterFootnoteContainer(el: any): any {
 		let current: any = el;
 		let parent: any = el.parentElement;
@@ -943,7 +962,7 @@ class FootnoteHandler {
 				footnoteData.refs.push(refId);
 
 				const container = this.findOuterFootnoteContainer(link);
-				container.replaceWith(this.createFootnoteReference(footnoteNumber, refId));
+				this.replaceContainerPreservingText(container, this.createFootnoteReference(footnoteNumber, refId));
 			});
 
 			// Pass 2: Match sup/span elements with numeric text (e.g. <sup class="footnote-ref">1</sup>)
@@ -978,7 +997,7 @@ class FootnoteHandler {
 					footnoteData.refs.push(refId);
 
 					const container = this.findOuterFootnoteContainer(el);
-					container.replaceWith(this.createFootnoteReference(footnoteNumber, refId));
+					this.replaceContainerPreservingText(container, this.createFootnoteReference(footnoteNumber, refId));
 				});
 			}
 		}

--- a/tests/expected/issues--218-footnote-wrapper-text-lost.md
+++ b/tests/expected/issues--218-footnote-wrapper-text-lost.md
@@ -1,0 +1,22 @@
+```json
+{
+  "title": "Footnotes in Wrapper Spans",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+First paragraph with enough content to ensure stable extraction. This text discusses various topics and provides a baseline for the content scoring algorithm to work with.
+
+Some sites wrap line-break hints around footnote-adjacent text. The word before the footnote is inside the same wrapper span as the reference.[^1] This continues after the footnote.
+
+Additional paragraph for content scoring stability. The algorithm needs sufficient text to correctly identify this as the main content area of the page.
+
+Another example where the wrapped word should be preserved.[^2] More text follows here.
+
+Final paragraph to ensure there is enough content for reliable extraction and to help the scoring algorithm identify the article body correctly.
+
+[^1]: First footnote content.
+
+[^2]: Second footnote content.

--- a/tests/fixtures/issues--218-footnote-wrapper-text-lost.html
+++ b/tests/fixtures/issues--218-footnote-wrapper-text-lost.html
@@ -1,0 +1,22 @@
+<!-- {"url":"https://example.org/articles/footnotes-in-wrapper-spans"} -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Footnotes in Wrapper Spans</title>
+</head>
+<body>
+<article>
+<h1>Footnotes in Wrapper Spans</h1>
+<p>First paragraph with enough content to ensure stable extraction. This text discusses various topics and provides a baseline for the content scoring algorithm to work with.</p>
+<p>Some sites wrap line-break hints around footnote-adjacent text. The word before the footnote is inside the same wrapper span as the <span class="wrap-inline">reference.<span id="ft-1" class="reference"> <sup class="footnote-ref">1</sup> </span></span>This continues after the footnote.</p>
+<p>Additional paragraph for content scoring stability. The algorithm needs sufficient text to correctly identify this as the main content area of the page.</p>
+<p>Another example where the wrapped word should be <span class="wrap-inline">preserved.<span id="ft-2" class="reference"> <sup class="footnote-ref">2</sup> </span></span>More text follows here.</p>
+<p>Final paragraph to ensure there is enough content for reliable extraction and to help the scoring algorithm identify the article body correctly.</p>
+<section class="footnotes"><ol class="footnotes-list">
+<li id="fn1" class="footnote-item"><p>First footnote content.</p></li>
+<li id="fn2" class="footnote-item"><p>Second footnote content.</p></li>
+</ol></section>
+</article>
+</body>
+</html>


### PR DESCRIPTION
Fixes #218.

`findOuterFootnoteContainer` walks up through all `span`/`sup` ancestors, which can land on a wrapper span that also contains visible text (e.g. `<span class="wrap-inline">discover.<span class="reference"><sup>7</sup></span></span>`). The primary inline-reference handler already preserves such text nodes, but the two fallback passes did a bare `replaceWith`, losing the text.

Extracts `replaceContainerPreservingText` (mirroring the existing logic in the primary handler) and uses it in both fallback paths.