### PR TITLE
Parse text content of <time> elements without datetime attribute

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -556,10 +556,12 @@ export class MetadataExtractor {
 	}
 
 	private static getTimeElement(doc: Document): string {
-		const selector = `time`;
-		const element = Array.from(doc.querySelectorAll(selector))[0];
-		const content = element ? (element.getAttribute("datetime")?.trim() ?? element.textContent?.trim() ?? "") : "";
-		return content;
+		const element = doc.querySelector('time');
+		if (!element) return '';
+		const datetime = element.getAttribute('datetime')?.trim();
+		if (datetime) return datetime;
+		const text = element.textContent?.trim() || '';
+		return this.parseDateText(text) || text;
 	}
 
 	private static readonly MONTH_MAP: Record<string, string> = {

--- a/tests/expected/metadata--time-element-no-datetime.md
+++ b/tests/expected/metadata--time-element-no-datetime.md
@@ -1,0 +1,12 @@
+```json
+{
+  "title": "Claude Managed Agents: get to production 10x faster",
+  "author": "",
+  "site": "",
+  "published": "2026-04-08T00:00:00+00:00"
+}
+```
+
+Today, we're launching Claude Managed Agents, a suite of composable APIs for building and deploying cloud-hosted agents at scale.
+
+Until now, building agents meant spending development cycles on secure infrastructure, state management, permissioning, and reworking your agent loops for every model upgrade.

--- a/tests/fixtures/metadata--time-element-no-datetime.html
+++ b/tests/fixtures/metadata--time-element-no-datetime.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Claude Managed Agents: get to production 10x faster</title>
+</head>
+<body>
+<article>
+<h1>Claude Managed Agents: get to production 10x faster</h1>
+<time>April 8, 2026</time>
+<p>Today, we're launching Claude Managed Agents, a suite of composable APIs for building and deploying cloud-hosted agents at scale.</p>
+<p>Until now, building agents meant spending development cycles on secure infrastructure, state management, permissioning, and reworking your agent loops for every model upgrade.</p>
+</article>
+</body>
+</html>


### PR DESCRIPTION
### Symptom

When a page has `<time>April 8, 2026</time>` (no `datetime` attribute), defuddle returns the raw text `"April 8, 2026"` as `published` instead of an ISO date string. Downstream consumers that pass this through `new Date()` get bitten by V8's quirk where `new Date("April 8")` returns `2001-04-08` — V8 substitutes year 2001 as a default for incomplete date strings.

### Cause

`getTimeElement` already had two paths:

1. `<time datetime="...">` → return the attribute (always ISO, fine)
2. `<time>April 8, 2026</time>` → return `textContent` (raw, not normalized)

Defuddle already has `parseDateText()` which converts `"February 26, 2025"` and `"26 February 2025"` into ISO. It just wasn't called on path 2.

### Fix

Run `parseDateText` on the text content before returning. Falls through to the raw text if the parser doesn't recognize the format, so existing inputs are unaffected.

```ts
private static getTimeElement(doc: Document): string {
    const element = doc.querySelector('time');
    if (!element) return '';
    const datetime = element.getAttribute('datetime')?.trim();
    if (datetime) return datetime;
    const text = element.textContent?.trim() || '';
    return this.parseDateText(text) || text;
}
```

Also replaced `Array.from(doc.querySelectorAll('time'))[0]` with `doc.querySelector('time')` — same selector, no `NodeList`/`Array` allocation.

### Test

New fixture `metadata--time-element-no-datetime.html` reproduces the bug with `<time>April 8, 2026</time>`. Expected `published`: `2026-04-08T00:00:00+00:00` (was `April 8, 2026`).

All 146 fixture tests pass, including the existing `issues--136-time-element` regression check (that fixture uses `datetime` attributes so the behavior is unchanged).

### Before / After

| Input | Before | After |
|---|---|---|
| `<time datetime="2025-01-15">15 Jan, 2025</time>` | `2025-01-15` | `2025-01-15` (unchanged) |
| `<time>April 8, 2026</time>` | `April 8, 2026` | `2026-04-08T00:00:00+00:00` |
| `<time>some unknown format</time>` | `some unknown format` | `some unknown format` (unchanged fallback) |
