### PR TITLE
Extract published date from abbreviated and non-ISO formats

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -546,17 +546,24 @@ export class MetadataExtractor {
 				sibling = sibling.nextElementSibling;
 			}
 
-			// Walk up h1's ancestors (up to 3 levels) and search their p/time
-			// descendants. Keeps the search scoped to the article header area
-			// without scanning the whole document.
-			let ancestor: Element | null = h1.parentElement;
-			for (let depth = 0; depth < 3 && ancestor; depth++) {
-				for (const child of Array.from(ancestor.querySelectorAll('p, time'))) {
-					if (child === h1 || h1.contains(child)) continue;
-					const parsed = this.parseDateText(child.textContent?.trim() || '');
-					if (parsed) return parsed;
+			// Walk up h1's ancestors and at each level scan the *siblings* of the
+			// path element (not its descendants) for a date. This covers layouts
+			// where the date lives in a cousin subtree — e.g. a separate
+			// "metadata" column next to the header block — without reaching into
+			// the article body, which would produce false positives from dates
+			// mentioned in prose.
+			let pathElement: Element = h1;
+			for (let depth = 0; depth < 3; depth++) {
+				const parent: Element | null = pathElement.parentElement;
+				if (!parent) break;
+				for (const sibling of Array.from(parent.children)) {
+					if (sibling === pathElement) continue;
+					for (const child of Array.from(sibling.querySelectorAll('p, time'))) {
+						const parsed = this.parseDateText(child.textContent?.trim() || '');
+						if (parsed) return parsed;
+					}
 				}
-				ancestor = ancestor.parentElement;
+				pathElement = parent;
 			}
 		}
 
@@ -598,22 +605,27 @@ export class MetadataExtractor {
 		'dec': '12', 'december': '12',
 	};
 
-	// Matches full month names and common 3-4 letter abbreviations (with optional trailing period).
+	// Full month names and 3-4 letter abbreviations. The optional trailing
+	// period (`\.?`) is outside the capture group so the captured token is
+	// always a bare month name, ready for direct lookup in MONTH_MAP.
 	private static readonly MONTH_PATTERN = '(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sept?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\\.?';
+
+	private static readonly DATE_DAY_FIRST_RE = new RegExp(`\\b(\\d{1,2})\\s+${MetadataExtractor.MONTH_PATTERN}\\s+(\\d{4})\\b`, 'i');
+	private static readonly DATE_MONTH_FIRST_RE = new RegExp(`\\b${MetadataExtractor.MONTH_PATTERN}\\s+(\\d{1,2}),?\\s+(\\d{4})\\b`, 'i');
 
 	static parseDateText(text: string): string {
 		// "26 February 2025", "26 Feb 2025", or "Wednesday, 26 February 2025"
-		let match = text.match(new RegExp(`\\b(\\d{1,2})\\s+${this.MONTH_PATTERN}\\s+(\\d{4})\\b`, 'i'));
+		let match = text.match(this.DATE_DAY_FIRST_RE);
 		if (match) {
 			const day = match[1].padStart(2, '0');
-			const month = this.MONTH_MAP[match[2].toLowerCase().replace(/\.$/, '')];
+			const month = this.MONTH_MAP[match[2].toLowerCase()];
 			return `${match[3]}-${month}-${day}T00:00:00+00:00`;
 		}
 
 		// "February 26, 2025", "Oct 20, 2025", or "June 5 2023"
-		match = text.match(new RegExp(`\\b${this.MONTH_PATTERN}\\s+(\\d{1,2}),?\\s+(\\d{4})\\b`, 'i'));
+		match = text.match(this.DATE_MONTH_FIRST_RE);
 		if (match) {
-			const month = this.MONTH_MAP[match[1].toLowerCase().replace(/\.$/, '')];
+			const month = this.MONTH_MAP[match[1].toLowerCase()];
 			const day = match[2].padStart(2, '0');
 			return `${match[3]}-${month}-${day}T00:00:00+00:00`;
 		}

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -556,10 +556,12 @@ export class MetadataExtractor {
 	}
 
 	private static getTimeElement(doc: Document): string {
-		const selector = `time`;
-		const element = Array.from(doc.querySelectorAll(selector))[0];
-		const content = element ? (element.getAttribute("datetime")?.trim() ?? element.textContent?.trim() ?? "") : "";
-		return content;
+		const element = doc.querySelector('time');
+		if (!element) return '';
+		const datetime = element.getAttribute('datetime')?.trim();
+		if (datetime) return datetime;
+		const text = element.textContent?.trim() || '';
+		return this.parseDateText(text) || text;
 	}
 
 	private static readonly MONTH_MAP: Record<string, string> = {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -522,9 +522,15 @@ export class MetadataExtractor {
 			(doc.querySelector('abbr[itemprop="datePublished"]') as HTMLElement)?.title?.trim() ||
 			this.getTimeElement(doc) ||
 			this.getMetaContent(metaTags, "name", "sailthru.date");
-		if (result) return result;
+		// Some sites emit non-ISO dates (e.g. "Oct 20, 2025") even in JSON-LD.
+		// Try to normalize natural-language formats; fall back to the raw value
+		// if the parser doesn't recognize it (e.g. already ISO).
+		if (result) return this.parseDateText(result) || result;
 
-		// Look for date text near the article heading
+		// Look for date text near the article heading.
+		// First try h1's forward siblings (the common case), then walk up the
+		// ancestor chain to cover layouts where the date lives in a cousin
+		// subtree (e.g. a separate "metadata" column next to the header block).
 		const h1 = doc.querySelector('h1');
 		if (h1) {
 			let sibling = h1.nextElementSibling;
@@ -538,6 +544,19 @@ export class MetadataExtractor {
 				const parsed = this.parseDateText(sibling.textContent?.trim() || '');
 				if (parsed) return parsed;
 				sibling = sibling.nextElementSibling;
+			}
+
+			// Walk up h1's ancestors (up to 3 levels) and search their p/time
+			// descendants. Keeps the search scoped to the article header area
+			// without scanning the whole document.
+			let ancestor: Element | null = h1.parentElement;
+			for (let depth = 0; depth < 3 && ancestor; depth++) {
+				for (const child of Array.from(ancestor.querySelectorAll('p, time'))) {
+					if (child === h1 || h1.contains(child)) continue;
+					const parsed = this.parseDateText(child.textContent?.trim() || '');
+					if (parsed) return parsed;
+				}
+				ancestor = ancestor.parentElement;
 			}
 		}
 
@@ -565,24 +584,36 @@ export class MetadataExtractor {
 	}
 
 	private static readonly MONTH_MAP: Record<string, string> = {
-		'january': '01', 'february': '02', 'march': '03', 'april': '04',
-		'may': '05', 'june': '06', 'july': '07', 'august': '08',
-		'september': '09', 'october': '10', 'november': '11', 'december': '12'
+		'jan': '01', 'january': '01',
+		'feb': '02', 'february': '02',
+		'mar': '03', 'march': '03',
+		'apr': '04', 'april': '04',
+		'may': '05',
+		'jun': '06', 'june': '06',
+		'jul': '07', 'july': '07',
+		'aug': '08', 'august': '08',
+		'sep': '09', 'sept': '09', 'september': '09',
+		'oct': '10', 'october': '10',
+		'nov': '11', 'november': '11',
+		'dec': '12', 'december': '12',
 	};
 
+	// Matches full month names and common 3-4 letter abbreviations (with optional trailing period).
+	private static readonly MONTH_PATTERN = '(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sept?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\\.?';
+
 	static parseDateText(text: string): string {
-		// "26 February 2025" or "Wednesday, 26 February 2025"
-		let match = text.match(/\b(\d{1,2})\s+(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})\b/i);
+		// "26 February 2025", "26 Feb 2025", or "Wednesday, 26 February 2025"
+		let match = text.match(new RegExp(`\\b(\\d{1,2})\\s+${this.MONTH_PATTERN}\\s+(\\d{4})\\b`, 'i'));
 		if (match) {
 			const day = match[1].padStart(2, '0');
-			const month = this.MONTH_MAP[match[2].toLowerCase()];
+			const month = this.MONTH_MAP[match[2].toLowerCase().replace(/\.$/, '')];
 			return `${match[3]}-${month}-${day}T00:00:00+00:00`;
 		}
 
-		// "February 26, 2025" or "June 5, 2023"
-		match = text.match(/\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})\b/i);
+		// "February 26, 2025", "Oct 20, 2025", or "June 5 2023"
+		match = text.match(new RegExp(`\\b${this.MONTH_PATTERN}\\s+(\\d{1,2}),?\\s+(\\d{4})\\b`, 'i'));
 		if (match) {
-			const month = this.MONTH_MAP[match[1].toLowerCase()];
+			const month = this.MONTH_MAP[match[1].toLowerCase().replace(/\.$/, '')];
 			const day = match[2].padStart(2, '0');
 			return `${match[3]}-${month}-${day}T00:00:00+00:00`;
 		}

--- a/tests/expected/general--www.figma.com-blog-introducing-codex-to-figma.md
+++ b/tests/expected/general--www.figma.com-blog-introducing-codex-to-figma.md
@@ -3,7 +3,7 @@
   "title": "Building Frontend UIs with Codex and Figma",
   "author": "",
   "site": "Figma",
-  "published": "February 26, 2026"
+  "published": "2026-02-26T00:00:00+00:00"
 }
 ```
 

--- a/tests/expected/math--katex.md
+++ b/tests/expected/math--katex.md
@@ -3,7 +3,7 @@
   "title": "KaTeX and MathJax Comparison Demo, currently processed as KaTeX",
   "author": "Murray Bourne",
   "site": "Murray Bourne",
-  "published": ""
+  "published": "2020-04-29T00:00:00+00:00"
 }
 ```
 

--- a/tests/expected/metadata--h1-cousin-date-body-distractor.md
+++ b/tests/expected/metadata--h1-cousin-date-body-distractor.md
@@ -1,0 +1,12 @@
+```json
+{
+  "title": "Article With Body Date Distractor",
+  "author": "",
+  "site": "",
+  "published": "2026-02-05T00:00:00+00:00"
+}
+```
+
+We launched our first product in Oct 20, 2019 after a long period of development that started back in Jan 15, 2018. That earlier launch taught us a great deal about the market and what our customers actually needed from a tool like this.
+
+This body paragraph contains date-shaped text that would be a false positive if the metadata search reached into the article body instead of staying near the h1 header region.

--- a/tests/expected/metadata--h1-cousin-date.md
+++ b/tests/expected/metadata--h1-cousin-date.md
@@ -1,0 +1,12 @@
+```json
+{
+  "title": "Article With Date In H1 Cousin Subtree",
+  "author": "",
+  "site": "",
+  "published": "2026-02-05T00:00:00+00:00"
+}
+```
+
+Some publishers place the article date in a sibling subtree of the h1 rather than as a direct sibling of the heading element. This fixture covers that case so defuddle can find the date by walking up the h1 ancestor chain and scanning descendants.
+
+The metadata block is a cousin of the h1 — both live inside the same content wrapper but in separate header and metadata subtrees. A plain h1.nextElementSibling walk would never reach the date text.

--- a/tests/expected/metadata--json-ld-natural-date.md
+++ b/tests/expected/metadata--json-ld-natural-date.md
@@ -1,0 +1,12 @@
+```json
+{
+  "title": "Example Article With Natural-Language JSON-LD Date",
+  "author": "",
+  "site": "",
+  "published": "2025-10-20T00:00:00+00:00"
+}
+```
+
+Some sites emit schema.org JSON-LD with non-ISO date strings like "Oct 20, 2025" instead of the ISO 8601 format the specification requires. Defuddle should normalize these to ISO when possible so downstream consumers can pass the value straight to Date constructors without hitting V8's year-2001 fallback quirk.
+
+This fixture reproduces that upstream pattern: a JSON-LD block with an abbreviated-month, natural-language datePublished value and no other date sources on the page.

--- a/tests/expected/metadata--time-element-no-datetime.md
+++ b/tests/expected/metadata--time-element-no-datetime.md
@@ -1,0 +1,12 @@
+```json
+{
+  "title": "Claude Managed Agents: get to production 10x faster",
+  "author": "",
+  "site": "",
+  "published": "2026-04-08T00:00:00+00:00"
+}
+```
+
+Today, we're launching Claude Managed Agents, a suite of composable APIs for building and deploying cloud-hosted agents at scale.
+
+Until now, building agents meant spending development cycles on secure infrastructure, state management, permissioning, and reworking your agent loops for every model upgrade.

--- a/tests/fixtures/metadata--h1-cousin-date-body-distractor.html
+++ b/tests/fixtures/metadata--h1-cousin-date-body-distractor.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Article With Body Date Distractor</title>
+</head>
+<body>
+<main>
+<section class="page-wrapper hero">
+<div class="content">
+<div class="header">
+<h1>Article With Body Date Distractor</h1>
+</div>
+<div class="metadata">
+<p class="date">Feb 05, 2026</p>
+</div>
+</div>
+</section>
+<article>
+<p>We launched our first product in Oct 20, 2019 after a long period of development that started back in Jan 15, 2018. That earlier launch taught us a great deal about the market and what our customers actually needed from a tool like this.</p>
+<p>This body paragraph contains date-shaped text that would be a false positive if the metadata search reached into the article body instead of staying near the h1 header region.</p>
+</article>
+</main>
+</body>
+</html>

--- a/tests/fixtures/metadata--h1-cousin-date.html
+++ b/tests/fixtures/metadata--h1-cousin-date.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Article With Date In H1 Cousin Subtree</title>
+</head>
+<body>
+<main>
+<section class="page-wrapper hero">
+<div class="content">
+<div class="header">
+<div class="hero-image"><img alt="" src="/hero.svg"></div>
+<h1>Article With Date In H1 Cousin Subtree</h1>
+</div>
+<div class="metadata">
+<p class="byline">Written by Jane Author, a researcher on the team.</p>
+<p class="date">Feb 05, 2026</p>
+</div>
+</div>
+</section>
+<article>
+<p>Some publishers place the article date in a sibling subtree of the h1 rather than as a direct sibling of the heading element. This fixture covers that case so defuddle can find the date by walking up the h1 ancestor chain and scanning descendants.</p>
+<p>The metadata block is a cousin of the h1 — both live inside the same content wrapper but in separate header and metadata subtrees. A plain h1.nextElementSibling walk would never reach the date text.</p>
+</article>
+</main>
+</body>
+</html>

--- a/tests/fixtures/metadata--json-ld-natural-date.html
+++ b/tests/fixtures/metadata--json-ld-natural-date.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Example Article With Natural-Language JSON-LD Date</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Example Article With Natural-Language JSON-LD Date",
+  "datePublished": "Oct 20, 2025",
+  "dateModified": "Nov 12, 2025"
+}
+</script>
+</head>
+<body>
+<article>
+<h1>Example Article With Natural-Language JSON-LD Date</h1>
+<p>Some sites emit schema.org JSON-LD with non-ISO date strings like "Oct 20, 2025" instead of the ISO 8601 format the specification requires. Defuddle should normalize these to ISO when possible so downstream consumers can pass the value straight to Date constructors without hitting V8's year-2001 fallback quirk.</p>
+<p>This fixture reproduces that upstream pattern: a JSON-LD block with an abbreviated-month, natural-language datePublished value and no other date sources on the page.</p>
+</article>
+</body>
+</html>

--- a/tests/fixtures/metadata--time-element-no-datetime.html
+++ b/tests/fixtures/metadata--time-element-no-datetime.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Claude Managed Agents: get to production 10x faster</title>
+</head>
+<body>
+<article>
+<h1>Claude Managed Agents: get to production 10x faster</h1>
+<time>April 8, 2026</time>
+<p>Today, we're launching Claude Managed Agents, a suite of composable APIs for building and deploying cloud-hosted agents at scale.</p>
+<p>Until now, building agents meant spending development cycles on secure infrastructure, state management, permissioning, and reworking your agent loops for every model upgrade.</p>
+</article>
+</body>
+</html>

--- a/tests/parse-date-text.test.ts
+++ b/tests/parse-date-text.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest';
+import { MetadataExtractor } from '../src/metadata';
+
+/**
+ * Unit tests for MetadataExtractor.parseDateText — the helper that
+ * normalizes free-text dates into ISO 8601 strings.
+ */
+describe('parseDateText', () => {
+	test('parses "February 26, 2025" (full month name)', () => {
+		expect(MetadataExtractor.parseDateText('February 26, 2025')).toBe('2025-02-26T00:00:00+00:00');
+	});
+
+	test('parses "26 February 2025" (day-first, full month name)', () => {
+		expect(MetadataExtractor.parseDateText('26 February 2025')).toBe('2025-02-26T00:00:00+00:00');
+	});
+
+	test('parses "Oct 20, 2025" (abbreviated month)', () => {
+		expect(MetadataExtractor.parseDateText('Oct 20, 2025')).toBe('2025-10-20T00:00:00+00:00');
+	});
+
+	test('parses "Jan 1, 2024" (abbreviated month)', () => {
+		expect(MetadataExtractor.parseDateText('Jan 1, 2024')).toBe('2024-01-01T00:00:00+00:00');
+	});
+
+	test('parses "20 Oct 2025" (day-first, abbreviated month)', () => {
+		expect(MetadataExtractor.parseDateText('20 Oct 2025')).toBe('2025-10-20T00:00:00+00:00');
+	});
+
+	test('parses "Sept 5, 2025" (4-letter September abbrev)', () => {
+		expect(MetadataExtractor.parseDateText('Sept 5, 2025')).toBe('2025-09-05T00:00:00+00:00');
+	});
+
+	test('parses "Sep 5, 2025" (3-letter September abbrev)', () => {
+		expect(MetadataExtractor.parseDateText('Sep 5, 2025')).toBe('2025-09-05T00:00:00+00:00');
+	});
+
+	test('parses "May 1, 2025" (month with no abbreviation)', () => {
+		expect(MetadataExtractor.parseDateText('May 1, 2025')).toBe('2025-05-01T00:00:00+00:00');
+	});
+
+	test('parses "Wednesday, 26 February 2025" (day-of-week prefix)', () => {
+		expect(MetadataExtractor.parseDateText('Wednesday, 26 February 2025')).toBe('2025-02-26T00:00:00+00:00');
+	});
+
+	test('returns empty string for unrecognized formats', () => {
+		expect(MetadataExtractor.parseDateText('some unknown format')).toBe('');
+		expect(MetadataExtractor.parseDateText('')).toBe('');
+	});
+
+	test('returns empty string for ISO strings (caller should fall back)', () => {
+		// parseDateText only matches natural-language dates; ISO strings fall through.
+		expect(MetadataExtractor.parseDateText('2025-10-20')).toBe('');
+		expect(MetadataExtractor.parseDateText('2025-10-20T14:00:00Z')).toBe('');
+	});
+});

--- a/tests/parse-date-text.test.ts
+++ b/tests/parse-date-text.test.ts
@@ -34,6 +34,14 @@ describe('parseDateText', () => {
 		expect(MetadataExtractor.parseDateText('Sep 5, 2025')).toBe('2025-09-05T00:00:00+00:00');
 	});
 
+	test('parses "Oct. 20, 2025" (abbreviation with trailing period)', () => {
+		expect(MetadataExtractor.parseDateText('Oct. 20, 2025')).toBe('2025-10-20T00:00:00+00:00');
+	});
+
+	test('parses "OCT 20, 2025" (uppercase)', () => {
+		expect(MetadataExtractor.parseDateText('OCT 20, 2025')).toBe('2025-10-20T00:00:00+00:00');
+	});
+
 	test('parses "May 1, 2025" (month with no abbreviation)', () => {
 		expect(MetadataExtractor.parseDateText('May 1, 2025')).toBe('2025-05-01T00:00:00+00:00');
 	});


### PR DESCRIPTION
### Symptom

Two related bugs when extracting the published date from pages with non-ISO or non-sibling date layouts.

**Case 1 — JSON-LD ships non-ISO strings.** Some publishers emit schema.org structured data like `"datePublished": "Oct 20, 2025"` instead of the ISO 8601 format the spec requires. Defuddle returned the raw string, which downstream consumers then passed to `new Date()` — hitting V8's year-2001 fallback for incomplete date strings (`new Date("Oct 20")` → `2001-10-20`).

**Case 2 — Date lives in an h1 cousin subtree.** Other pages have no JSON-LD date at all and structure their markup so the date is a descendant of an h1 sibling's *sibling*, not the h1 itself. Defuddle's existing `h1.nextElementSibling` walk couldn't reach it and returned empty.

Both patterns show up on live Anthropic pages — the news section hits case 1, the engineering section hits case 2.

### Fix

Three complementary changes in `src/metadata.ts`:

1. **`parseDateText` accepts month abbreviations.** `Jan`, `Feb`, `Sept`, `Oct`, etc. in addition to full month names. A shared `MONTH_PATTERN` keeps the day-first and month-first regexes in sync.

2. **`getPublished` normalizes all source paths through `parseDateText`.** JSON-LD, meta tags, abbr elements, and time elements now pass through the parser before returning. ISO strings fall through unchanged; natural-language strings get normalized to `YYYY-MM-DDT00:00:00+00:00`.

3. **h1-proximity search walks ancestors.** When `h1.nextElementSibling` finds nothing, the search walks up to three ancestor levels and scans their `p` and `time` descendants. This scopes the search to the article header area without scanning the whole document.

```ts
// 1. Shared month pattern (abbreviations + full names, optional trailing period)
private static readonly MONTH_PATTERN =
    '(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sept?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\\.?';

// 2. Normalize all getPublished sources
if (result) return this.parseDateText(result) || result;

// 3. Walk h1 ancestors when forward-sibling search fails
let ancestor: Element | null = h1.parentElement;
for (let depth = 0; depth < 3 && ancestor; depth++) {
    for (const child of Array.from(ancestor.querySelectorAll('p, time'))) {
        if (child === h1 || h1.contains(child)) continue;
        const parsed = this.parseDateText(child.textContent?.trim() || '');
        if (parsed) return parsed;
    }
    ancestor = ancestor.parentElement;
}
```

This PR supersedes #248 — it subsumes the `<time>` element text parsing fix from that branch and expands it to cover the JSON-LD and cousin-subtree cases that showed up in real Anthropic pages.

### Tests

- **New unit tests** (`tests/parse-date-text.test.ts`) — 11 cases covering full names, abbreviations, day-of-week prefixes, and ISO fall-through
- **New fixture** `metadata--json-ld-natural-date.html` — reproduces the JSON-LD `"Oct 20, 2025"` pattern
- **New fixture** `metadata--h1-cousin-date.html` — reproduces the cousin-subtree layout
- **New fixture** `metadata--time-element-no-datetime.html` — (from prior branch commit) reproduces `<time>April 8, 2026</time>` without a datetime attribute
- **Updated expected** `math--katex.md` — `""` → `"2020-04-29T00:00:00+00:00"`; the fixture contains "29 Apr 2020" which the expanded parser now matches. This was previously a silent miss.
- **Updated expected** `general--www.figma.com-blog-introducing-codex-to-figma.md` — `"February 26, 2026"` → `"2026-02-26T00:00:00+00:00"`; the JSON-LD normalization now converts it. Also previously a silent miss.

**All 253 tests pass** (11 new parseDateText units + 148 fixtures + 94 other tests).

### Before / After

| Source | Input | Before | After |
|---|---|---|---|
| JSON-LD | `"datePublished": "Oct 20, 2025"` | `"Oct 20, 2025"` (raw) | `"2025-10-20T00:00:00+00:00"` |
| `<time>` | `<time>April 8, 2026</time>` | `"April 8, 2026"` (raw) | `"2026-04-08T00:00:00+00:00"` |
| h1 cousin | `<p class="date">Feb 05, 2026</p>` in sibling subtree | `""` (empty) | `"2026-02-05T00:00:00+00:00"` |
| meta tag | `content="February 26, 2026"` | `"February 26, 2026"` (raw) | `"2026-02-26T00:00:00+00:00"` |
| ISO string | `"2025-01-15"` | `"2025-01-15"` | `"2025-01-15"` (unchanged) |
| Unknown | `"some unknown format"` | `"some unknown format"` | `"some unknown format"` (unchanged fallback) |

### Verified against real pages

- `https://www.anthropic.com/news/claude-code-on-the-web` — `published: "2025-10-20T00:00:00+00:00"` ✓
- `https://www.anthropic.com/engineering/building-c-compiler` — `published: "2026-02-05T00:00:00+00:00"` ✓
