### PR TITLE
Fix: findTableBasedContent selects TOC cells over actual content

### DIFF
--- a/src/defuddle.ts
+++ b/src/defuddle.ts
@@ -1153,8 +1153,27 @@ export class Defuddle {
 			return null; // Don't try table-based extraction for modern layouts
 		}
 
-		const cells = Array.from(doc.getElementsByTagName('td'));
-		return ContentScorer.findBestElement(cells);
+		const tocSelector = '#toc, .toc, .Toc, .table-of-contents, [role="directory"]';
+		const cells = Array.from(doc.getElementsByTagName('td')).filter(cell => {
+			// Skip cells inside or containing TOC elements — they hold navigation, not content
+			return !cell.closest(tocSelector) && !cell.querySelector(tocSelector);
+		});
+
+		const bestCell = ContentScorer.findBestElement(cells);
+		if (!bestCell) return null;
+
+		// Check if there's substantial content outside of tables (free-flowing
+		// headings and paragraphs). If the body has far more text outside tables
+		// than inside the best cell, the tables are peripheral (TOC, intro boxes,
+		// quotes) — not the main content container.
+		const bestCellWords = countWords(bestCell.textContent || '');
+		const body = doc.body || doc.documentElement;
+		const bodyWords = countWords(body.textContent || '');
+		if (bestCellWords < bodyWords * 0.33) {
+			return null;
+		}
+
+		return bestCell;
 	}
 
 	private findContentByScoring(doc: Document): Element | null {

--- a/tests/expected/table-layout--toc-outside-content.md
+++ b/tests/expected/table-layout--toc-outside-content.md
@@ -1,0 +1,86 @@
+```json
+{
+  "title": "A comprehensive guide to better habits",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+### Author Name, January 2020
+
+## Introduction
+
+Habits shape every aspect of our daily lives. Research in behavioral psychology has shown that roughly forty percent of our actions on any given day are driven not by conscious decisions but by habits. Understanding how habits work gives us a powerful framework for self-improvement. This guide synthesizes findings from neuroscience, psychology, and practical experience to offer a comprehensive approach to building good habits and breaking bad ones.
+
+The process of habit formation has been studied extensively over the past several decades. Scientists have identified the habit loop, consisting of a cue, a routine, and a reward, as the fundamental mechanism underlying all habitual behavior. By learning to recognize and manipulate these components, anyone can reshape their daily patterns.
+
+### Background
+
+The study of habits dates back to early psychological research in the nineteenth century. William James wrote extensively about the power of habit in shaping character and productivity. Modern neuroscience has confirmed many of his intuitions, showing that habitual behaviors are processed in the basal ganglia, a region deep within the brain that operates largely outside conscious awareness.
+
+When a behavior becomes habitual, the brain creates neural pathways that allow the action to be performed with minimal cognitive effort. This is why habits feel automatic, and why they can be so difficult to change once established. The prefrontal cortex, responsible for deliberate decision-making, gradually hands off control to these deeper brain structures.
+
+### Motivation
+
+Many people rely on motivation to drive behavior change, but motivation is inherently unreliable. It fluctuates with mood, energy levels, and external circumstances. Habits, by contrast, persist even when motivation wanes. The goal of this guide is to help you build systems that do not depend on willpower or motivation alone.
+
+## Core principles
+
+### Consistency
+
+The single most important factor in habit formation is consistency. Performing a behavior at the same time, in the same context, day after day, strengthens the neural pathways associated with that behavior. Studies have shown that it takes an average of sixty-six days for a new behavior to become automatic, though this varies widely depending on the complexity of the habit and individual differences.
+
+Consistency matters more than intensity. It is better to exercise for ten minutes every day than to exercise for two hours once a week. The regularity of the behavior is what signals to the brain that this action is important enough to automate.
+
+### Environment design
+
+Your environment has a profound influence on your behavior. People who successfully build good habits often redesign their environment to make desired behaviors easier and undesired behaviors harder. This might mean placing a book on your pillow so you read before bed, or removing unhealthy snacks from your kitchen so you are not tempted.
+
+Research by behavioral scientists has demonstrated that even small changes to the physical environment can produce large changes in behavior. The key insight is that much of our behavior is triggered by environmental cues rather than conscious choices. By controlling those cues, we can shape our actions.
+
+Effective habit systems incorporate feedback loops that reinforce desired behaviors. Immediate rewards are particularly powerful because the brain prioritizes short-term outcomes over long-term benefits. Finding ways to make good habits immediately satisfying increases the likelihood that they will stick.
+
+Tracking your habits provides a visual feedback loop that can be highly motivating. Each day that you mark as complete creates a chain of progress that you become reluctant to break. This simple technique leverages loss aversion, one of the most powerful forces in human psychology.
+
+## Building habits
+
+### Start small
+
+One of the most common mistakes people make when trying to build new habits is starting too big. They commit to running five miles a day or meditating for an hour each morning, and when they inevitably fail to maintain that pace, they give up entirely. A much more effective approach is to start with a habit so small that it requires almost no effort.
+
+The two-minute rule suggests that when you start a new habit, it should take less than two minutes to complete. Want to build a reading habit? Start by reading one page per day. Want to start exercising? Begin with a single pushup. The goal is not the immediate outcome but the establishment of the routine itself.
+
+### Stack habits
+
+Habit stacking is a technique that leverages existing habits as triggers for new ones. The formula is simple: after I perform a current habit, I will perform a new habit. For example, after I pour my morning coffee, I will write in my journal for two minutes. By linking the new behavior to an established routine, you take advantage of the neural pathways that already exist.
+
+This approach works because it provides a clear cue for the new behavior. Rather than relying on vague intentions like I will meditate more, you create a specific plan tied to a concrete trigger. Implementation intentions, as researchers call them, dramatically increase the likelihood of follow-through.
+
+### Track progress
+
+Measurement is a critical component of any habit-building system. What gets measured gets managed. Keeping a simple habit tracker, whether on paper or in a digital app, provides accountability and makes your progress visible. It also helps you identify patterns, such as which days you tend to skip or which habits are most difficult to maintain.
+
+## Breaking bad habits
+
+### Identify triggers
+
+Breaking a bad habit begins with understanding what triggers it. Every habit has a cue, and identifying that cue is the first step toward change. Common triggers include stress, boredom, social pressure, and environmental cues. By keeping a log of when and where you engage in the unwanted behavior, patterns will emerge that reveal the underlying triggers.
+
+Once you have identified the triggers, you can develop strategies to avoid or mitigate them. If stress triggers unhealthy eating, you might develop alternative stress-management techniques such as deep breathing or brief walks. If a particular environment triggers the behavior, you can modify or avoid that environment.
+
+### Replace the routine
+
+Research has shown that habits cannot simply be eliminated. Instead, they must be replaced. The cue and reward remain the same, but the routine changes. A smoker who feels the urge to smoke after meals might replace the cigarette with a piece of gum or a short walk. The key is that the replacement behavior must provide a similar type of reward.
+
+This substitution approach is more effective than willpower-based suppression because it works with the brain's habit machinery rather than against it. The neural pathways associated with the old habit do not disappear, but new pathways can be built alongside them, gradually becoming the dominant response to the trigger.
+
+## Summary
+
+Building good habits and breaking bad ones is not about willpower or motivation. It is about understanding the mechanics of habit formation and designing systems that work in your favor. Start small, be consistent, design your environment, track your progress, and replace bad habits rather than trying to eliminate them through sheer force of will. With patience and the right approach, lasting behavior change is within reach for everyone.
+
+## References
+
+1. James, W. (1890). *The Principles of Psychology*. New York: Henry Holt and Company.
+2. Lally, P., et al. (2010). "How are habits formed: Modelling habit formation in the real world." *European Journal of Social Psychology*, 40(6), 998-1009.
+3. Wood, W., & Neal, D. T. (2007). "A new look at habits and the habit-goal interface." *Psychological Review*, 114(4), 843-863.

--- a/tests/fixtures/table-layout--toc-outside-content.html
+++ b/tests/fixtures/table-layout--toc-outside-content.html
@@ -1,0 +1,175 @@
+<!-- {"url": "https://example.com/articles/guide.htm"} -->
+<!DOCTYPE html>
+<html>
+<head>
+	<title>A comprehensive guide to better habits</title>
+</head>
+<body>
+	<h1>A comprehensive guide to better habits</h1>
+	<h3><a href="/about.htm">Author Name</a>, January 2020</h3>
+	<div id="bodyContent">
+		<table id="toc" class="toc" align="center"><tr><td><div id="toctitle"><h2>Contents</h2></div>
+			<div id="toc_proper">
+			<ul>
+				<li class="toclevel-1 tocsection-1"><a href="#Introduction">1 Introduction to habit formation and behavioral change</a>
+					<ul>
+						<li class="toclevel-2 tocsection-2"><a href="#Background">1.1 Historical background and early psychological research</a></li>
+						<li class="toclevel-2 tocsection-3"><a href="#Motivation">1.2 The complex role of intrinsic and extrinsic motivation</a></li>
+						<li class="toclevel-2 tocsection-4"><a href="#Neuroscience">1.3 Neuroscience of habit formation in the basal ganglia</a></li>
+						<li class="toclevel-2 tocsection-5"><a href="#Prefrontal">1.4 Prefrontal cortex and the deliberate decision system</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-6"><a href="#Core_principles">2 Core principles of effective habit building strategies</a>
+					<ul>
+						<li class="toclevel-2 tocsection-7"><a href="#Consistency">2.1 The fundamental importance of daily consistency</a></li>
+						<li class="toclevel-2 tocsection-8"><a href="#Environment">2.2 Environment design and contextual behavioral cues</a></li>
+						<li class="toclevel-2 tocsection-9"><a href="#Feedback_loops">2.3 Feedback loops and positive reinforcement mechanisms</a></li>
+						<li class="toclevel-2 tocsection-10"><a href="#Identity">2.4 Identity-based habit formation and self-image transformation</a></li>
+						<li class="toclevel-2 tocsection-11"><a href="#Keystone">2.5 Keystone habits that trigger widespread cascading change</a></li>
+						<li class="toclevel-2 tocsection-12"><a href="#Willpower">2.6 Understanding willpower depletion and decision fatigue</a></li>
+						<li class="toclevel-2 tocsection-13"><a href="#Reward_systems">2.7 The neuroscience of reward systems and dopamine pathways</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-14"><a href="#Building_habits">3 Practical strategies for building new positive habits</a>
+					<ul>
+						<li class="toclevel-2 tocsection-15"><a href="#Start_small">3.1 Starting small with the powerful two-minute rule</a></li>
+						<li class="toclevel-2 tocsection-16"><a href="#Stack_habits">3.2 Habit stacking and implementation intention planning</a></li>
+						<li class="toclevel-2 tocsection-17"><a href="#Track_progress">3.3 Tracking progress and maintaining personal accountability</a></li>
+						<li class="toclevel-2 tocsection-18"><a href="#Rewards">3.4 Designing immediately satisfying reward systems</a></li>
+						<li class="toclevel-2 tocsection-19"><a href="#Social">3.5 Social accountability groups and shared habit commitments</a></li>
+						<li class="toclevel-2 tocsection-20"><a href="#Plateau">3.6 Overcoming the frustrating plateau of latent potential</a></li>
+						<li class="toclevel-2 tocsection-21"><a href="#Temptation">3.7 Temptation bundling and making habits attractive</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-22"><a href="#Breaking_habits">4 Breaking bad habits and eliminating unwanted behaviors</a>
+					<ul>
+						<li class="toclevel-2 tocsection-23"><a href="#Identify_triggers">4.1 Identifying environmental and deep emotional triggers</a></li>
+						<li class="toclevel-2 tocsection-24"><a href="#Replace_routine">4.2 Replacing the routine while preserving the reward</a></li>
+						<li class="toclevel-2 tocsection-25"><a href="#Friction">4.3 Adding friction to make bad habits increasingly difficult</a></li>
+						<li class="toclevel-2 tocsection-26"><a href="#Mindfulness">4.4 Mindfulness and awareness-based cognitive approaches</a></li>
+						<li class="toclevel-2 tocsection-27"><a href="#Accountability">4.5 Accountability partners and commitment device contracts</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-28"><a href="#Sleep_and_habits">5 The critical relationship between sleep and habit formation</a>
+					<ul>
+						<li class="toclevel-2 tocsection-29"><a href="#Sleep_consolidation">5.1 Memory consolidation during deep sleep cycles</a></li>
+						<li class="toclevel-2 tocsection-30"><a href="#Sleep_willpower">5.2 How chronic sleep deprivation depletes willpower reserves</a></li>
+						<li class="toclevel-2 tocsection-31"><a href="#Sleep_routine">5.3 Building and maintaining a consistent bedtime routine</a></li>
+						<li class="toclevel-2 tocsection-32"><a href="#Circadian">5.4 Working with your natural circadian rhythm cycle</a></li>
+						<li class="toclevel-2 tocsection-33"><a href="#Napping">5.5 Strategic afternoon napping for cognitive performance</a></li>
+						<li class="toclevel-2 tocsection-34"><a href="#Dreams">5.6 The role of dreams in emotional processing and learning</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-35"><a href="#Exercise_habits">6 Exercise and physical activity habit development</a>
+					<ul>
+						<li class="toclevel-2 tocsection-36"><a href="#Exercise_consistency">6.1 Building exercise consistency rather than intensity focus</a></li>
+						<li class="toclevel-2 tocsection-37"><a href="#Exercise_timing">6.2 Optimal timing for different types of physical activity</a></li>
+						<li class="toclevel-2 tocsection-38"><a href="#Exercise_types">6.3 Types of exercise and their unique habit-forming potential</a></li>
+						<li class="toclevel-2 tocsection-39"><a href="#Morning_routine">6.4 Designing an effective morning exercise routine ritual</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-40"><a href="#Diet_habits">7 Nutritional habits and sustainable dietary patterns</a>
+					<ul>
+						<li class="toclevel-2 tocsection-41"><a href="#Meal_planning">7.1 Meal planning and weekly preparation strategies</a></li>
+						<li class="toclevel-2 tocsection-42"><a href="#Mindful_eating">7.2 Mindful eating practices and portion awareness techniques</a></li>
+						<li class="toclevel-2 tocsection-43"><a href="#Sugar_habits">7.3 Breaking sugar and processed food dependency cycles</a></li>
+						<li class="toclevel-2 tocsection-44"><a href="#Hydration">7.4 Building consistent hydration and water intake habits</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-45"><a href="#Learning_habits">8 Learning and intellectual growth habits</a>
+					<ul>
+						<li class="toclevel-2 tocsection-46"><a href="#Reading">8.1 Building a sustainable daily reading practice habit</a></li>
+						<li class="toclevel-2 tocsection-47"><a href="#Spaced_repetition">8.2 Spaced repetition systems and memory optimization strategies</a></li>
+						<li class="toclevel-2 tocsection-48"><a href="#Deep_work">8.3 Deep work sessions and sustained focused concentration</a></li>
+						<li class="toclevel-2 tocsection-49"><a href="#Journaling">8.4 Reflective journaling and systematic self-assessment practice</a></li>
+						<li class="toclevel-2 tocsection-50"><a href="#Teaching">8.5 Teaching others as a method for reinforcing your learning</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-51"><a href="#Workplace">9 Habits in professional life and the modern workplace</a>
+					<ul>
+						<li class="toclevel-2 tocsection-52"><a href="#Productivity">9.1 Productivity systems and effective time management habits</a></li>
+						<li class="toclevel-2 tocsection-53"><a href="#Communication">9.2 Communication habits for improved team collaboration</a></li>
+						<li class="toclevel-2 tocsection-54"><a href="#Leadership">9.3 Leadership habits and building positive organizational culture</a></li>
+						<li class="toclevel-2 tocsection-55"><a href="#Remote">9.4 Remote work habits and maintaining work-life boundaries</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-56"><a href="#Technology">10 Technology and digital habit management strategies</a>
+					<ul>
+						<li class="toclevel-2 tocsection-57"><a href="#Screen_time">10.1 Managing daily screen time and reducing digital distractions</a></li>
+						<li class="toclevel-2 tocsection-58"><a href="#Apps">10.2 Using modern apps and tools for effective habit tracking</a></li>
+						<li class="toclevel-2 tocsection-59"><a href="#Social_media">10.3 Social media consumption patterns and healthy usage limits</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-60"><a href="#Myths">11 Common myths and misconceptions about habit formation</a>
+					<ul>
+						<li class="toclevel-2 tocsection-61"><a href="#21days">11.1 The persistent myth of the twenty-one day habit rule</a></li>
+						<li class="toclevel-2 tocsection-62"><a href="#Willpower_myth">11.2 Why willpower alone is never sufficient for lasting change</a></li>
+						<li class="toclevel-2 tocsection-63"><a href="#Perfection">11.3 The dangerous perfectionism trap and all-or-nothing thinking</a></li>
+					</ul>
+				</li>
+				<li class="toclevel-1 tocsection-64"><a href="#Summary">12 Summary and practical key takeaways for implementation</a></li>
+				<li class="toclevel-1 tocsection-65"><a href="#References">13 References and recommended further reading materials</a></li>
+			</ul>
+			</div>
+		</td></tr></table>
+
+		<h2><span class="mw-headline" id="Introduction">Introduction</span></h2>
+		<p>Habits shape every aspect of our daily lives. Research in behavioral psychology has shown that roughly forty percent of our actions on any given day are driven not by conscious decisions but by habits. Understanding how habits work gives us a powerful framework for self-improvement. This guide synthesizes findings from neuroscience, psychology, and practical experience to offer a comprehensive approach to building good habits and breaking bad ones.</p>
+		<p>The process of habit formation has been studied extensively over the past several decades. Scientists have identified the habit loop, consisting of a cue, a routine, and a reward, as the fundamental mechanism underlying all habitual behavior. By learning to recognize and manipulate these components, anyone can reshape their daily patterns.</p>
+
+		<h3><span class="mw-headline" id="Background">Background</span></h3>
+		<p>The study of habits dates back to early psychological research in the nineteenth century. William James wrote extensively about the power of habit in shaping character and productivity. Modern neuroscience has confirmed many of his intuitions, showing that habitual behaviors are processed in the basal ganglia, a region deep within the brain that operates largely outside conscious awareness.</p>
+		<p>When a behavior becomes habitual, the brain creates neural pathways that allow the action to be performed with minimal cognitive effort. This is why habits feel automatic, and why they can be so difficult to change once established. The prefrontal cortex, responsible for deliberate decision-making, gradually hands off control to these deeper brain structures.</p>
+
+		<h3><span class="mw-headline" id="Motivation">Motivation</span></h3>
+		<p>Many people rely on motivation to drive behavior change, but motivation is inherently unreliable. It fluctuates with mood, energy levels, and external circumstances. Habits, by contrast, persist even when motivation wanes. The goal of this guide is to help you build systems that do not depend on willpower or motivation alone.</p>
+
+		<h2><span class="mw-headline" id="Core_principles">Core principles</span></h2>
+
+		<h3><span class="mw-headline" id="Consistency">Consistency</span></h3>
+		<p>The single most important factor in habit formation is consistency. Performing a behavior at the same time, in the same context, day after day, strengthens the neural pathways associated with that behavior. Studies have shown that it takes an average of sixty-six days for a new behavior to become automatic, though this varies widely depending on the complexity of the habit and individual differences.</p>
+		<p>Consistency matters more than intensity. It is better to exercise for ten minutes every day than to exercise for two hours once a week. The regularity of the behavior is what signals to the brain that this action is important enough to automate.</p>
+
+		<h3><span class="mw-headline" id="Environment">Environment design</span></h3>
+		<p>Your environment has a profound influence on your behavior. People who successfully build good habits often redesign their environment to make desired behaviors easier and undesired behaviors harder. This might mean placing a book on your pillow so you read before bed, or removing unhealthy snacks from your kitchen so you are not tempted.</p>
+		<p>Research by behavioral scientists has demonstrated that even small changes to the physical environment can produce large changes in behavior. The key insight is that much of our behavior is triggered by environmental cues rather than conscious choices. By controlling those cues, we can shape our actions.</p>
+
+		<h3><span class="mw-headline" id="Feedback_loops">Feedback loops</span></h3>
+		<p>Effective habit systems incorporate feedback loops that reinforce desired behaviors. Immediate rewards are particularly powerful because the brain prioritizes short-term outcomes over long-term benefits. Finding ways to make good habits immediately satisfying increases the likelihood that they will stick.</p>
+		<p>Tracking your habits provides a visual feedback loop that can be highly motivating. Each day that you mark as complete creates a chain of progress that you become reluctant to break. This simple technique leverages loss aversion, one of the most powerful forces in human psychology.</p>
+
+		<h2><span class="mw-headline" id="Building_habits">Building habits</span></h2>
+
+		<h3><span class="mw-headline" id="Start_small">Start small</span></h3>
+		<p>One of the most common mistakes people make when trying to build new habits is starting too big. They commit to running five miles a day or meditating for an hour each morning, and when they inevitably fail to maintain that pace, they give up entirely. A much more effective approach is to start with a habit so small that it requires almost no effort.</p>
+		<p>The two-minute rule suggests that when you start a new habit, it should take less than two minutes to complete. Want to build a reading habit? Start by reading one page per day. Want to start exercising? Begin with a single pushup. The goal is not the immediate outcome but the establishment of the routine itself.</p>
+
+		<h3><span class="mw-headline" id="Stack_habits">Stack habits</span></h3>
+		<p>Habit stacking is a technique that leverages existing habits as triggers for new ones. The formula is simple: after I perform a current habit, I will perform a new habit. For example, after I pour my morning coffee, I will write in my journal for two minutes. By linking the new behavior to an established routine, you take advantage of the neural pathways that already exist.</p>
+		<p>This approach works because it provides a clear cue for the new behavior. Rather than relying on vague intentions like I will meditate more, you create a specific plan tied to a concrete trigger. Implementation intentions, as researchers call them, dramatically increase the likelihood of follow-through.</p>
+
+		<h3><span class="mw-headline" id="Track_progress">Track progress</span></h3>
+		<p>Measurement is a critical component of any habit-building system. What gets measured gets managed. Keeping a simple habit tracker, whether on paper or in a digital app, provides accountability and makes your progress visible. It also helps you identify patterns, such as which days you tend to skip or which habits are most difficult to maintain.</p>
+
+		<h2><span class="mw-headline" id="Breaking_habits">Breaking bad habits</span></h2>
+
+		<h3><span class="mw-headline" id="Identify_triggers">Identify triggers</span></h3>
+		<p>Breaking a bad habit begins with understanding what triggers it. Every habit has a cue, and identifying that cue is the first step toward change. Common triggers include stress, boredom, social pressure, and environmental cues. By keeping a log of when and where you engage in the unwanted behavior, patterns will emerge that reveal the underlying triggers.</p>
+		<p>Once you have identified the triggers, you can develop strategies to avoid or mitigate them. If stress triggers unhealthy eating, you might develop alternative stress-management techniques such as deep breathing or brief walks. If a particular environment triggers the behavior, you can modify or avoid that environment.</p>
+
+		<h3><span class="mw-headline" id="Replace_routine">Replace the routine</span></h3>
+		<p>Research has shown that habits cannot simply be eliminated. Instead, they must be replaced. The cue and reward remain the same, but the routine changes. A smoker who feels the urge to smoke after meals might replace the cigarette with a piece of gum or a short walk. The key is that the replacement behavior must provide a similar type of reward.</p>
+		<p>This substitution approach is more effective than willpower-based suppression because it works with the brain's habit machinery rather than against it. The neural pathways associated with the old habit do not disappear, but new pathways can be built alongside them, gradually becoming the dominant response to the trigger.</p>
+
+		<h2><span class="mw-headline" id="Summary">Summary</span></h2>
+		<p>Building good habits and breaking bad ones is not about willpower or motivation. It is about understanding the mechanics of habit formation and designing systems that work in your favor. Start small, be consistent, design your environment, track your progress, and replace bad habits rather than trying to eliminate them through sheer force of will. With patience and the right approach, lasting behavior change is within reach for everyone.</p>
+
+		<h2><span class="mw-headline" id="References">References</span></h2>
+		<ol>
+			<li>James, W. (1890). <i>The Principles of Psychology</i>. New York: Henry Holt and Company.</li>
+			<li>Lally, P., et al. (2010). "How are habits formed: Modelling habit formation in the real world." <i>European Journal of Social Psychology</i>, 40(6), 998-1009.</li>
+			<li>Wood, W., & Neal, D. T. (2007). "A new look at habits and the habit-goal interface." <i>Psychological Review</i>, 114(4), 843-863.</li>
+		</ol>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
### Summary
- `findTableBasedContent()` picks the highest-scoring `<td>` cell without checking if it's a TOC or navigation element. On pages where tables are used for peripheral layout (TOC, intro boxes, quotes) but the main article content is free-flowing outside tables, this causes the entire article to be discarded.
- Filter out `<td>` cells inside or containing known TOC selectors (`#toc`, `.toc`, etc.) since these are already removed by `EXACT_SELECTORS` during cleanup — but content selection runs before cleanup.
- Reject candidate cells that contain less than 33% of the body's text, indicating the tables are peripheral rather than structural content containers.

✅ Fixes Issue: https://github.com/kepano/defuddle/issues/258
✅ Added Tests Fixtures

**Results**
Website - https://super-memory.com/articles/sleep.htm
Old Defuddle Result -  [Partial Article Parsed ⚠️](https://gist.github.com/kothariji/04a48a1262b5513ec992f2a3e5d19f66)
New Defuddle Result - [Full Article Parsed ✅](https://gist.github.com/kothariji/392954fc8858d8490342952e6bf1e5a0)