### PR TITLE
fix: remove empty video placeholders from extracted content

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -98,6 +98,7 @@ export const EXACT_SELECTORS = [
 
 	// empty media elements (src set by JS at runtime, not in raw HTML)
 	'audio:not([src])',
+	'video:not([src]):not(:has(source))',
 
 	// ads
 	'.ad:not([class*="gradient"])',

--- a/tests/expected/issues--254-empty-video.md
+++ b/tests/expected/issues--254-empty-video.md
@@ -1,0 +1,12 @@
+```json
+{
+  "title": "Empty Video Placeholder",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+This fixture models a page that includes a JavaScript-driven video shell without any media source in the static HTML. The article text is intentionally long enough to keep main content detection stable during tests and to ensure the empty player is evaluated as part of the extracted content.
+
+The player above should be removed because it has no src attribute and no source child elements. Keeping it would leak useless raw HTML into the extracted markdown output.

--- a/tests/fixtures/issues--254-empty-video.html
+++ b/tests/fixtures/issues--254-empty-video.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Empty Video Placeholder</title>
+</head>
+<body>
+<article>
+<h1>Empty Video Placeholder</h1>
+<p>This fixture models a page that includes a JavaScript-driven video shell without any media source in the static HTML. The article text is intentionally long enough to keep main content detection stable during tests and to ensure the empty player is evaluated as part of the extracted content.</p>
+<video id="video" playsinline controls controlsList="nodownload" width="100%" height="100%" onplay="player.start();"></video>
+<p>The player above should be removed because it has no src attribute and no source child elements. Keeping it would leak useless raw HTML into the extracted markdown output.</p>
+</article>
+</body>
+</html>

--- a/tests/media-removal.test.ts
+++ b/tests/media-removal.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest';
+import { Defuddle } from '../src/node';
+import { parseDocument } from './helpers';
+
+describe('Media removal', () => {
+	test('preserves video elements that use source children', async () => {
+		const html = `<!DOCTYPE html>
+<html>
+<head><title>Video With Source</title></head>
+<body>
+<article>
+<h1>Video With Source</h1>
+<p>This article includes a real video element that uses nested source tags instead of a src attribute on the video element itself.</p>
+<video controls poster="https://example.com/poster.jpg">
+	<source src="https://example.com/video.mp4" type="video/mp4">
+</video>
+<p>The video should remain in the extracted HTML because it has a valid media source.</p>
+</article>
+</body>
+</html>`;
+
+		const result = await Defuddle(
+			parseDocument(html, 'https://example.com/video-with-source'),
+			'https://example.com/video-with-source',
+			{ separateMarkdown: true }
+		);
+
+		expect(result.content).toContain('<video');
+		expect(result.content).toContain('<source');
+		expect(result.content).toContain('https://example.com/video.mp4');
+	});
+});


### PR DESCRIPTION
Closes #254.

## Summary
- remove `<video>` elements that have neither a `src` attribute nor any `<source>` children
- keep real videos that provide media via nested `<source>` tags
- add a fixture regression test for the empty placeholder case

## Testing
- npm test -- tests/fixtures.test.ts tests/media-removal.test.ts