### PR TITLE
Add Bilibili extractor and transcript extraction support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -169,7 +168,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1435,7 +1433,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1471,7 +1468,6 @@
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -1604,7 +1600,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2727,7 +2722,6 @@
 			"integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssstyle": "^4.0.1",
 				"data-urls": "^5.0.0",
@@ -3558,7 +3552,6 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
 			"integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.8.2",
@@ -3668,7 +3661,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3794,7 +3786,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
 			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3872,7 +3863,6 @@
 			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -3989,7 +3979,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -4151,7 +4140,6 @@
 			"integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -4200,7 +4188,6 @@
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",

--- a/src/extractor-registry.ts
+++ b/src/extractor-registry.ts
@@ -4,6 +4,7 @@ import { BaseExtractor, ExtractorOptions } from './extractors/_base';
 import { RedditExtractor } from './extractors/reddit';
 import { TwitterExtractor } from './extractors/twitter';
 import { XArticleExtractor } from './extractors/x-article';
+import { BilibiliExtractor } from './extractors/bilibili';
 import { YoutubeExtractor } from './extractors/youtube';
 import { HackerNewsExtractor } from './extractors/hackernews';
 import { ChatGPTExtractor } from './extractors/chatgpt';
@@ -82,6 +83,13 @@ export class ExtractorRegistry {
 				/youtu\.be\/.*/
 			],
 			extractor: YoutubeExtractor
+		});
+
+		this.register({
+			patterns: [
+				'bilibili.com',
+			],
+			extractor: BilibiliExtractor
 		});
 
 		this.register({

--- a/src/extractors/bilibili.ts
+++ b/src/extractors/bilibili.ts
@@ -1,0 +1,292 @@
+import type {
+	ExtractorResult,
+	TranscriptResult
+} from '../types/extractors';
+import type { TranscriptChapter } from '../utils/transcript';
+import { buildTranscript } from '../utils/transcript';
+import { BaseExtractor, ExtractorOptions } from './_base';
+
+import {
+	MID_TEXT_SENTENCE_BOUNDARY,
+	SENTENCE_END,
+	TRANSCRIPT_GROUP_GAP_SECONDS,
+	TRANSCRIPT_MAX_GROUP_SECONDS,
+} from './youtube'
+
+const BILIBILI_PLAYER_URL = "https://player.bilibili.com/player.html";
+const BILIBILI_TRANSCRIPT_API = "https://api.bilibili.com/x/player/wbi/v2?";
+
+export class BilibiliExtractor extends BaseExtractor {
+	private videoElement: HTMLVideoElement | null;
+	private inlineJsonCache = new Map<string, any>();
+	protected override schemaOrgData: any;
+
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: ExtractorOptions) {
+		super(document, url, schemaOrgData, options);
+		this.videoElement = document.querySelector('video');
+		this.schemaOrgData = schemaOrgData;
+	}
+
+	canExtract(): boolean {
+		return true;
+	}
+
+	canExtractAsync(): boolean {
+		return true;
+	}
+
+	prefersAsync(): boolean {
+		return true;
+	}
+
+	// BilibiliExtractor does not support synchronous extraction with transcript because the transcript needs to be fetched from the API, which is an asynchronous operation.
+	// The extract method will return the basic video information without the transcript, while extractAsync will include the transcript if available.
+	extract(): ExtractorResult {
+		return this.buildResult();
+	}
+
+	async extractAsync(): Promise<ExtractorResult> {
+		const transcript = await this.fetchTranscript();
+		return this.buildResult(transcript);
+	}
+
+	private async fetchTranscript(): Promise<TranscriptResult | undefined> {
+		try {
+			const videoData = this.getVideoData();
+			const bvid = videoData.bvid;
+			const cid = videoData.cid;
+
+			if (!bvid || !cid) {
+				return undefined;
+			}
+
+			const url = `${BILIBILI_TRANSCRIPT_API}bvid=${bvid}&cid=${cid}`;
+			// Bilibili's transcript API requires cookies for authentication, so we need to include credentials in the request. Or the transcript url will be empty.
+			const response = await this.fetch(url, { credentials: 'include' });
+			const data = await response.json();
+			const transcriptsURL = data?.data?.subtitle?.subtitles;
+			const chapters = this.formatChapters(data?.data?.view_points);
+
+			if (!transcriptsURL || transcriptsURL.length === 0) {
+				return undefined;
+			}
+
+			// Bilibili's API may return subtitles with mutliple languages.
+			// If user has selected a transcript language in the video player, the selected language will extracted.
+			// Otherwise, the first subtitle in the list will be extracted.
+			const selectedLanguage = this.document.querySelector(".bpx-player-ctrl-subtitle-language-item.bpx-state-active")?.getAttribute("data-lan") || this.normalizeLanguageCode(this.options.language);
+			const targetTranscriptURL = transcriptsURL.filter((t: any) => this.normalizeLanguageCode(t.lan) === this.normalizeLanguageCode(selectedLanguage));
+			const transcriptURL = targetTranscriptURL.length > 0 ? targetTranscriptURL[0] : transcriptsURL[0];
+
+			const languageCode = this.normalizeLanguageCode(transcriptURL.lan);
+
+			const transcriptResponse = await this.fetch(transcriptURL.subtitle_url);
+			const transcriptData = await transcriptResponse.json();
+			const transcript = transcriptData?.body || [];
+
+			const { html, text } = this.parseTranscripts(transcript, chapters);
+
+			return { html, text, languageCode };
+
+		} catch (error) {
+			console.error('BilibiliExtractor: failed to fetch transcript', error);
+			return undefined;
+		}
+	}
+
+	private buildResult(transcript?: TranscriptResult): ExtractorResult {
+		const videoData = this.getVideoData();
+		const channelName = videoData.owner?.name || '';
+		const description = videoData.desc || '';
+		const formattedDescription = this.formatDescription(description);
+
+		const queryParam = new URLSearchParams({
+			aid: videoData.aid,
+			bvid: videoData.bvid,
+			cid: videoData.cid,
+			p: videoData.p,
+			autoplay: '0',
+		});
+		const style="position: relative; max-width: 720px; width: 100%; height: auto; aspect-ratio: 16/9 "
+		let contentHtml = `<iframe `
+			+` style="${style}" `
+			+` src="${BILIBILI_PLAYER_URL}?${queryParam.toString()}" `
+			+` frameborder="0" `
+			+` allowfullscreen `
+			+` ></iframe>\n${formattedDescription}`;
+
+		if (transcript?.html) {
+			contentHtml += transcript.html;
+		}
+
+		const variables: { [key: string]: string } = {
+			title: videoData.title || '',
+			author: channelName,
+			site: 'Bilibili',
+			image: videoData.pic || '',
+			published: videoData.pubdate,
+			description: description.slice(0, 200).trim(),
+		};
+
+		if (transcript?.text) {
+			variables.transcript = transcript.text;
+		}
+
+		if (transcript?.languageCode) {
+			variables.language = transcript.languageCode;
+		}
+
+		return {
+			content: contentHtml,
+			contentHtml: contentHtml,
+			extractedContent: {
+				videoId: videoData.aid || '',
+				author: channelName,
+			},
+			variables,
+		};
+	}
+
+
+	// Bilibili Web Page will inject the video data into the global variable `__INITIAL_STATE__` when the page loads. We can extract the video information from there.
+	private getVideoData(): { [key: string]: any } {
+		const videoData = (window as any).__INITIAL_STATE__?.videoData || {};
+		if ((window as any).__INITIAL_STATE__?.p) {
+			videoData.cid = (window as any).__INITIAL_STATE__.cid;
+			videoData.p = (window as any).__INITIAL_STATE__.p;
+		}
+		return videoData;
+	}
+
+	private formatDescription(description: string): string {
+		return `<p>${description.replace(/\n/g, '<br>')}</p>`;
+	}
+
+	private normalizeLanguageCode(code?: string): string {
+		return (code || '').trim().replace(/_/g, '-').toLocaleLowerCase();
+	}
+
+	private formatChapters(chapters?: any[]): TranscriptChapter[] {
+		if (!chapters || !Array.isArray(chapters)) {
+			return [];
+		}
+
+		return chapters.map((c) => {
+			return { start: c.from, title: c.content };
+		})
+	}
+
+	private parseTranscripts(transcripts: any[], chapters: TranscriptChapter[]): TranscriptResult {
+		const segments: { start: number; text: string }[] = [];
+
+		for (const item of transcripts) {
+			const text = item.content.replace(/\s+/g, ' ').trim();
+			if (text) {
+				segments.push({ start: item.from, text });
+			}
+		}
+
+		if (segments.length === 0) return { html: '', text: '' };
+		console.log('Raw segments:', segments);
+		const groups = this.groupBySentence(segments);
+		return buildTranscript('bilibili', groups, chapters);
+	}
+
+	// For bilibili transcripts, there are no speaker markers, so we will group the segments into sentences based on punctuation and timing gaps.
+	private groupBySentence(segments: { start: number; text: string }[]): { start: number; text: string; speakerChange: boolean; speaker?: number }[] {
+		const groups: { start: number; text: string; speakerChange: boolean }[] = [];
+		const pending: { start: number; text: string }[] = [];
+
+		const pushGroup = (segs: { start: number; text: string }[]) => {
+			const text = segs.map(s => s.text).join(' ').trim();
+			if (text) {
+				groups.push({ start: segs[0].start, text, speakerChange: false });
+			}
+		};
+
+		const flushAll = () => {
+			if (pending.length === 0) return;
+			pushGroup(pending);
+			pending.length = 0;
+		};
+
+		const flushUpTo = (idx: number) => {
+			if (idx <= 0) return;
+			pushGroup(pending.splice(0, idx));
+		};
+
+		for (const seg of segments) {
+			// Treat bilibili as Youtube
+			// YouTube often emits sparse caption windows 10-15s apart even when the
+			// sentence is still continuing, so only treat very large gaps as breaks.
+			if (pending.length > 0 && seg.start - pending[pending.length - 1].start > TRANSCRIPT_GROUP_GAP_SECONDS) {
+				flushAll();
+			}
+
+			pending.push(seg);
+
+			if (SENTENCE_END.test(seg.text)) {
+				flushAll();
+				continue;
+			}
+
+			// For unpunctuated ASR transcripts, break at the best natural
+			// point once the group exceeds TRANSCRIPT_MAX_GROUP_SECONDS.
+			if (seg.start - pending[0].start >= TRANSCRIPT_MAX_GROUP_SECONDS) {
+				const breakIdx = this.findNaturalBreak(pending);
+				if (breakIdx > 0 && breakIdx < pending.length) {
+					flushUpTo(breakIdx);
+				} else {
+					flushAll();
+				}
+			}
+		}
+
+		flushAll();
+		return groups;
+	}
+
+	/**
+	 * Find the best natural break point in a list of segments.
+	 * Prefers mid-text sentence boundaries (". A") over gap-based breaks.
+	 * May splice a segment in two when a sentence boundary is found mid-text.
+	 * Returns the index to break BEFORE (i.e., flush segments 0..idx-1).
+	 */
+	private findNaturalBreak(segments: { start: number; text: string }[]): number {
+		if (segments.length <= 1) return -1;
+
+		const minStart = segments[0].start + TRANSCRIPT_MAX_GROUP_SECONDS / 2;
+
+		// Priority 1: last segment containing a mid-text sentence boundary.
+		// Split that segment so the boundary falls at a clean edge.
+		for (let i = segments.length - 1; i >= 0; i--) {
+			if (segments[i].start < minStart) break;
+			const match = segments[i].text.match(MID_TEXT_SENTENCE_BOUNDARY);
+			if (match) {
+				const before = match[1] ?? match[3];
+				const after = match[2] ?? match[4];
+				const start = segments[i].start;
+				segments.splice(i, 1,
+					{ start, text: before },
+					{ start, text: after },
+				);
+				return i + 1;
+			}
+		}
+
+		// Priority 2: largest gap (natural pause) in the eligible range.
+		let bestIdx = -1;
+		let bestGap = 0;
+
+		for (let i = 1; i < segments.length; i++) {
+			if (segments[i].start < minStart) continue;
+			const gap = segments[i].start - segments[i - 1].start;
+			if (gap >= bestGap) {
+				bestGap = gap;
+				bestIdx = i;
+			}
+		}
+
+		return bestIdx;
+	}
+}

--- a/src/extractors/youtube.ts
+++ b/src/extractors/youtube.ts
@@ -4,27 +4,27 @@ import { escapeHtml } from '../utils/dom';
 import { countWords, CJK_CHAR_RANGES } from '../utils';
 import { buildTranscript } from '../utils/transcript';
 
-const CJK_SENTENCE_PUNCT = '\u3002\uFF01\uFF1F';  // 。！？
-const CJK_CLOSE_QUOTES = '\u300D\u300F\uFF09';    // 」』）
-const SENTENCE_END = new RegExp(`[.!?${CJK_SENTENCE_PUNCT}]["'\\u2019\\u201D)${CJK_CLOSE_QUOTES}]*\\s*$`);
-const QUESTION_END = new RegExp(`[?\\uFF1F]["'\\u2019\\u201D)${CJK_CLOSE_QUOTES}]*\\s*$`);
-const SPEAKER_MARKER = /^(>>|-\s)/;
-const SPEAKER_STRIP = /^(>>\s*|-\s+)/;
-const TRAILING_COMMA = /,\s*$/;
-const TRANSCRIPT_GROUP_GAP_SECONDS = 20;
-const TRANSCRIPT_MAX_GROUP_SECONDS = 30;
+export const CJK_SENTENCE_PUNCT = '\u3002\uFF01\uFF1F';  // 。！？
+export const CJK_CLOSE_QUOTES = '\u300D\u300F\uFF09';    // 」』）
+export const SENTENCE_END = new RegExp(`[.!?${CJK_SENTENCE_PUNCT}]["'\\u2019\\u201D)${CJK_CLOSE_QUOTES}]*\\s*$`);
+export const QUESTION_END = new RegExp(`[?\\uFF1F]["'\\u2019\\u201D)${CJK_CLOSE_QUOTES}]*\\s*$`);
+export const SPEAKER_MARKER = /^(>>|-\s)/;
+export const SPEAKER_STRIP = /^(>>\s*|-\s+)/;
+export const TRAILING_COMMA = /,\s*$/;
+export const TRANSCRIPT_GROUP_GAP_SECONDS = 20;
+export const TRANSCRIPT_MAX_GROUP_SECONDS = 30;
 // Latin: sentence punct + optional quotes + whitespace + uppercase letter
 // CJK: fullwidth sentence punct + optional close quotes + any CJK character (no space needed)
-const MID_TEXT_SENTENCE_BOUNDARY = new RegExp(
+export const MID_TEXT_SENTENCE_BOUNDARY = new RegExp(
 	`^(.*[.!?]["'\\u2019\\u201D)]*)\\s+([A-Z].*)$` +
 	`|^(.*[${CJK_SENTENCE_PUNCT}][${CJK_CLOSE_QUOTES}]*)([${CJK_CHAR_RANGES}].*)$`
 );
-const TURN_MERGE_MAX_WORDS = 80;
-const TURN_MERGE_MAX_SPAN_SECONDS = 45;
-const SHORT_UTTERANCE_MAX_WORDS = 3;
-const FIRST_GROUP_MERGE_MIN_WORDS = 8;
+export const TURN_MERGE_MAX_WORDS = 80;
+export const TURN_MERGE_MAX_SPAN_SECONDS = 45;
+export const SHORT_UTTERANCE_MAX_WORDS = 3;
+export const FIRST_GROUP_MERGE_MIN_WORDS = 8;
 
-const FETCH_TIMEOUT_MS = 4000;
+export const FETCH_TIMEOUT_MS = 4000;
 
 // Unofficial InnerTube API. Uses Android client context to get caption track URLs.
 // Version may need updating if Google changes the API.

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -349,7 +349,8 @@ export function createMarkdownContent(content: string, url: string) {
 			const src = node.getAttribute('src');
 			return !!src && (
 				!!src.match(/(?:youtube\.com|youtube-nocookie\.com|youtu\.be)/) ||
-				!!src.match(/(?:twitter\.com|x\.com)/)
+				!!src.match(/(?:twitter\.com|x\.com)/) ||
+				!!src.match(/(?:bilibili\.com|bilibili\.tv)/)
 			);
 		},
 		replacement: function (content: string, node: Node): string {

--- a/src/types/extractors.ts
+++ b/src/types/extractors.ts
@@ -1,3 +1,9 @@
+export interface TranscriptResult {
+	html: string;
+	text: string;
+	languageCode?: string;
+}
+
 export interface ConversationMessage {
 	author: string;
 	content: string;


### PR DESCRIPTION

## Relative Issue
Close #268 

## Changes
- **New Bilibili Extractor**: Implemented `BilibiliExtractor` (`src/extractors/bilibili.ts`), which handles Bilibili's specific API to fetch video data and subtitles/transcripts, mimicking the grouping behavior used for YouTube transcripts.
- **Extractor Registry**: Registered `BilibiliExtractor` in `src/extractor-registry.ts` to trigger on `bilibili.com` URLs.
- **Markdown Rendering**: Updated `src/markdown.ts` to ensure `bilibili.com` and `bilibili.tv` iframe embeds are retained in the final generated Markdown.
- **Shared Transcript Logic**: Exported transcript parsing constants (e.g., `SENTENCE_END`, `TRANSCRIPT_GROUP_GAP_SECONDS`, `MID_TEXT_SENTENCE_BOUNDARY`) from `src/extractors/youtube.ts` to reuse them within the Bilibili extractor.
- **Type Definitions**: Extracted and centralized the `TranscriptResult` interface in `src/types/extractors.ts`.
- **Lockfile Updates**: Minor updates to `package-lock.json` resolving some `peer` dependency flags.

## Relative Doc
- [Bilibili External Player User Guide](https://player.bilibili.com/)