### PR TITLE
Add Bilibili video subtitle/transcript extraction

### DIFF
--- a/src/extractor-registry.ts
+++ b/src/extractor-registry.ts
@@ -5,6 +5,7 @@ import { RedditExtractor } from './extractors/reddit';
 import { TwitterExtractor } from './extractors/twitter';
 import { XArticleExtractor } from './extractors/x-article';
 import { YoutubeExtractor } from './extractors/youtube';
+import { BilibiliExtractor } from './extractors/bilibili';
 import { HackerNewsExtractor } from './extractors/hackernews';
 import { ChatGPTExtractor } from './extractors/chatgpt';
 import { ClaudeExtractor } from './extractors/claude';
@@ -79,6 +80,14 @@ export class ExtractorRegistry {
 				/youtu\.be\/.*/
 			],
 			extractor: YoutubeExtractor
+		});
+
+		this.register({
+			patterns: [
+				'bilibili.com',
+				/www\.bilibili\.com\/video\/BV[0-9A-Za-z]+/,
+			],
+			extractor: BilibiliExtractor
 		});
 
 		this.register({

--- a/src/extractors/bilibili.ts
+++ b/src/extractors/bilibili.ts
@@ -1,0 +1,496 @@
+import { BaseExtractor, ExtractorOptions } from './_base';
+import { ExtractorResult } from '../types/extractors';
+import { escapeHtml } from '../utils/dom';
+import { buildTranscript, TranscriptSegment, TranscriptResult as BuiltTranscript } from '../utils/transcript';
+
+const FETCH_TIMEOUT_MS = 4000;
+const TRANSCRIPT_GROUP_GAP_SECONDS = 20;
+const TRANSCRIPT_MAX_GROUP_SECONDS = 30;
+const HAN_CHAR = /[\u4E00-\u9FFF]/;
+
+type ViewApiPage = {
+	cid: number;
+	page: number;
+	part?: string;
+	duration?: number;
+};
+
+type ViewApiData = {
+	bvid: string;
+	aid: number;
+	title?: string;
+	desc?: string;
+	pic?: string;
+	pubdate?: number;
+	owner?: { name?: string };
+	pages?: ViewApiPage[];
+};
+
+type ViewApiResponse = {
+	code: number;
+	message?: string;
+	data?: ViewApiData;
+};
+
+type PlayerSubtitleTrack = {
+	lan: string;
+	lan_doc?: string;
+	subtitle_url: string;
+	id?: number;
+	is_ai_subtitle?: boolean;
+};
+
+type PlayerV2Response = {
+	code: number;
+	message?: string;
+	data?: {
+		subtitle?: {
+			subtitles?: PlayerSubtitleTrack[];
+		};
+	};
+};
+
+type SubtitleLine = {
+	from: number;
+	to?: number;
+	content: string;
+};
+
+type SubtitleJson = {
+	body?: SubtitleLine[];
+};
+
+type TranscriptResult = BuiltTranscript & { languageCode?: string };
+
+export class BilibiliExtractor extends BaseExtractor {
+	private static transcriptCache = new Map<string, TranscriptResult | null>();
+	private _bvid: string | undefined;
+
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: ExtractorOptions) {
+		super(document, url, schemaOrgData, options);
+	}
+
+	canExtract(): boolean {
+		return !!this.getBvid();
+	}
+
+	canExtractAsync(): boolean {
+		return this.canExtract();
+	}
+
+	prefersAsync(): boolean {
+		return true;
+	}
+
+	extract(): ExtractorResult {
+		return this.buildResult();
+	}
+
+	async extractAsync(): Promise<ExtractorResult> {
+		const bvid = this.getBvid();
+		if (!bvid) return this.buildResult();
+
+		const view = await this.fetchViewData(bvid);
+		if (!view) return this.buildResult();
+
+		const { aid, pages = [] } = view;
+		const pageNumber = this.getPageNumber();
+		const pageInfo = (pages.length > 0 ? (pages[pageNumber - 1] ?? pages[0]) : undefined);
+		const cid = pageInfo?.cid;
+		const preferredLang = this.normalizeLanguageCode(this.options.language);
+		const cacheKey = (aid && cid) ? `${bvid}:${cid}:${preferredLang}` : '';
+
+		let transcript: TranscriptResult | undefined;
+		if (aid && cid) {
+			if (cacheKey && BilibiliExtractor.transcriptCache.has(cacheKey)) {
+				const cached = BilibiliExtractor.transcriptCache.get(cacheKey);
+				transcript = cached ?? undefined;
+			} else {
+				transcript = await this.fetchTranscript(aid, cid, bvid);
+				if (cacheKey) {
+					BilibiliExtractor.transcriptCache.set(cacheKey, transcript ?? null);
+					if (BilibiliExtractor.transcriptCache.size > 300) {
+						const firstKey = BilibiliExtractor.transcriptCache.keys().next().value;
+						if (firstKey) BilibiliExtractor.transcriptCache.delete(firstKey);
+					}
+				}
+			}
+		}
+
+		return this.buildResult(transcript, view, pageInfo, pageNumber);
+	}
+
+	private getBvid(): string {
+		if (this._bvid !== undefined) return this._bvid;
+		try {
+			const url = new URL(this.url);
+			const match = url.pathname.match(/\/video\/(BV[0-9A-Za-z]+)\/?/);
+			this._bvid = match?.[1] ?? '';
+		} catch {
+			this._bvid = '';
+		}
+		return this._bvid;
+	}
+
+	private getPageNumber(): number {
+		try {
+			const url = new URL(this.url);
+			const p = parseInt(new URLSearchParams(url.search).get('p') || '1', 10);
+			return Number.isFinite(p) && p > 0 ? p : 1;
+		} catch {
+			return 1;
+		}
+	}
+
+	private formatDescription(desc: string): string {
+		const safe = escapeHtml(desc).replace(/\n/g, '<br>');
+		return safe ? `<p>${safe}</p>` : '';
+	}
+
+	private buildEmbedHtml(bvid: string, pageNumber: number): string {
+		const src = `https://player.bilibili.com/player.html?bvid=${encodeURIComponent(bvid)}&page=${pageNumber}&high_quality=1&danmaku=0`;
+		return `<iframe width="560" height="315" src="${src}" title="Bilibili video player" frameborder="0" allowfullscreen></iframe>`;
+	}
+
+	private buildResult(
+		transcript?: TranscriptResult,
+		view?: ViewApiData,
+		pageInfo?: ViewApiPage,
+		pageNumber?: number,
+	): ExtractorResult {
+		const bvid = this.getBvid();
+		const title = view?.title || this.document.title || '';
+		const author = view?.owner?.name || '';
+		const desc = view?.desc || '';
+		const description = desc.slice(0, 200).trim();
+		const image = view?.pic || '';
+		const published = view?.pubdate ? new Date(view.pubdate * 1000).toISOString() : '';
+
+		let contentHtml = '';
+		if (bvid) {
+			contentHtml += this.buildEmbedHtml(bvid, pageNumber || this.getPageNumber());
+		}
+		if (desc) {
+			contentHtml += this.formatDescription(desc);
+		}
+		if (transcript?.html) {
+			contentHtml += transcript.html;
+		}
+
+		const variables: { [key: string]: string } = {
+			title,
+			author,
+			site: 'Bilibili',
+			image,
+			published,
+			description,
+		};
+
+		if (pageInfo?.part) {
+			variables.part = pageInfo.part;
+		}
+
+		if (transcript?.text) {
+			variables.transcript = transcript.text;
+		}
+		if (transcript?.languageCode) {
+			variables.language = transcript.languageCode;
+		}
+
+		return {
+			content: contentHtml,
+			contentHtml,
+			extractedContent: {
+				videoId: bvid,
+				...(pageInfo?.cid ? { cid: String(pageInfo.cid) } : {}),
+			},
+			variables,
+		};
+	}
+
+
+	private normalizeLanguageCode(code?: string): string {
+		return (code || '').trim().replace(/_/g, '-').toLocaleLowerCase();
+	}
+
+	private pickSubtitleTrack(tracks: PlayerSubtitleTrack[], preferredLang?: string): PlayerSubtitleTrack | undefined {
+		if (tracks.length === 0) return undefined;
+
+		const pref = this.normalizeLanguageCode(preferredLang);
+		const prefBase = pref ? pref.split('-')[0] : '';
+
+		const stableUrlKey = (u?: string): string => {
+			const input = (u || '').trim();
+			if (!input) return '';
+			try {
+				const normalized = input.startsWith('//') ? `https:${input}` : input;
+				const parsed = new URL(normalized);
+				return `${parsed.hostname.toLocaleLowerCase()}${parsed.pathname}`;
+			} catch {
+				return input.split('?')[0].split('#')[0];
+			}
+		};
+
+		const normalizeDoc = (doc?: string): string => (doc || '').trim().toLocaleLowerCase();
+		const isLikelyAiDoc = (doc?: string): boolean => {
+			const d = normalizeDoc(doc);
+			return d.includes('ai') || d.includes('auto') || d.includes('自动');
+		};
+
+		const langPriority = (code: string): number => {
+			// Stable language preference when no explicit language provided.
+			if (code === 'zh-cn' || code === 'zh-hans') return 0;
+			if (code === 'zh') return 1;
+			if (code.startsWith('zh-')) return 2;
+			if (code === 'en' || code.startsWith('en-')) return 3;
+			return 4;
+		};
+
+		const ranked = tracks
+			.map((t, index) => {
+				const code = this.normalizeLanguageCode(t.lan);
+				let prefScore = 3;
+				if (pref) {
+					if (code === pref) prefScore = 0;
+					else if (prefBase && code === prefBase) prefScore = 1;
+					else if (prefBase && code.split('-')[0] === prefBase) prefScore = 2;
+				}
+
+				const aiScore = t.is_ai_subtitle || isLikelyAiDoc(t.lan_doc) ? 1 : 0;
+				const lp = langPriority(code);
+				const id = typeof t.id === 'number' ? t.id : Number.MAX_SAFE_INTEGER;
+				const doc = normalizeDoc(t.lan_doc);
+				const urlKey = stableUrlKey(t.subtitle_url);
+
+				return { t, prefScore, aiScore, lp, id, doc, urlKey, index };
+			})
+			.sort((a, b) => {
+				if (a.prefScore !== b.prefScore) return a.prefScore - b.prefScore;
+				if (a.aiScore !== b.aiScore) return a.aiScore - b.aiScore;
+				if (a.lp !== b.lp) return a.lp - b.lp;
+				if (a.id !== b.id) return a.id - b.id;
+				if (a.doc !== b.doc) return a.doc.localeCompare(b.doc);
+				if (a.urlKey !== b.urlKey) return a.urlKey.localeCompare(b.urlKey);
+				return a.index - b.index;
+			});
+
+		return ranked[0]?.t;
+	}
+
+	private async fetchViewData(bvid: string): Promise<ViewApiData | undefined> {
+		try {
+			const url = `https://api.bilibili.com/x/web-interface/view?bvid=${encodeURIComponent(bvid)}`;
+			const response = await this.fetch(url, {
+				headers: {
+					'Accept': 'application/json',
+					'User-Agent': 'Mozilla/5.0 (compatible; Defuddle/1.0)',
+				},
+				credentials: 'include' as RequestCredentials,
+				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			});
+			if (!response.ok) return undefined;
+			const json = await response.json() as ViewApiResponse;
+			if (json?.code !== 0) return undefined;
+			return json.data;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private parseSubtitleTracks(json: any): PlayerSubtitleTrack[] {
+		const candidates = [
+			json?.data?.subtitle?.subtitles,
+			json?.data?.subtitle?.list,
+			json?.data?.subtitle?.tracks,
+		];
+		for (const cand of candidates) {
+			if (!Array.isArray(cand)) continue;
+			return cand
+				.map((t: any) => ({
+					lan: String(t?.lan ?? t?.lang ?? t?.language ?? ''),
+					lan_doc: t?.lan_doc ? String(t.lan_doc) : undefined,
+					subtitle_url: String(t?.subtitle_url ?? t?.subtitleUrl ?? t?.url ?? ''),
+					id: typeof t?.id === 'number' ? t.id : (typeof t?.subtitle_id === 'number' ? t.subtitle_id : undefined),
+					is_ai_subtitle: typeof t?.is_ai_subtitle === 'boolean'
+						? t.is_ai_subtitle
+						: (typeof t?.ai_type === 'number' ? t.ai_type > 0 : undefined),
+				}))
+				.filter((t: PlayerSubtitleTrack) => !!t.lan && !!t.subtitle_url);
+		}
+		return [];
+	}
+
+	private async fetchPlayerV2(url: string): Promise<{ tracks: PlayerSubtitleTrack[]; code?: number; message?: string }> {
+		const response = await this.fetch(url, {
+			headers: {
+				'Accept': 'application/json',
+				'User-Agent': 'Mozilla/5.0 (compatible; Defuddle/1.0)',
+			},
+			credentials: 'include' as RequestCredentials,
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		});
+		if (!response.ok) {
+			return { tracks: [], code: response.status, message: `http_${response.status}` };
+		}
+		const json = await response.json() as PlayerV2Response;
+		const code = typeof (json as any)?.code === 'number' ? (json as any).code : undefined;
+		const message = typeof (json as any)?.message === 'string' ? (json as any).message : undefined;
+		if (code !== 0) {
+			return { tracks: [], code, message };
+		}
+		return { tracks: this.parseSubtitleTracks(json), code, message };
+	}
+
+	private async fetchTranscript(aid: number, cid: number, bvid: string): Promise<TranscriptResult | undefined> {
+		try {
+			// Deterministic API order to minimize drift across repeated extraction:
+			// 1) wbi/v2 (most complete), 2) v2 with bvid+cid, 3) v2 with aid+cid.
+			const urlWbi = `https://api.bilibili.com/x/player/wbi/v2?bvid=${encodeURIComponent(String(bvid))}&aid=${encodeURIComponent(String(aid))}&cid=${encodeURIComponent(String(cid))}`;
+			const urlBvid = `https://api.bilibili.com/x/player/v2?bvid=${encodeURIComponent(String(bvid))}&cid=${encodeURIComponent(String(cid))}`;
+			const urlAid = `https://api.bilibili.com/x/player/v2?aid=${encodeURIComponent(String(aid))}&cid=${encodeURIComponent(String(cid))}`;
+
+			let tracks: PlayerSubtitleTrack[] = [];
+			const first = await this.fetchPlayerV2(urlWbi);
+			tracks = first.tracks;
+
+			if (tracks.length === 0) {
+				const second = await this.fetchPlayerV2(urlBvid);
+				tracks = second.tracks;
+				if (tracks.length === 0) {
+					const third = await this.fetchPlayerV2(urlAid);
+					tracks = third.tracks;
+				}
+			}
+
+			if (!Array.isArray(tracks) || tracks.length === 0) {
+				return undefined;
+			}
+
+			const picked = this.pickSubtitleTrack(tracks, this.options.language);
+			if (!picked?.subtitle_url) {
+				return undefined;
+			}
+
+			const subtitleUrl = this.normalizeSubtitleUrl(picked.subtitle_url);
+			if (!subtitleUrl) {
+				return undefined;
+			}
+			if (!this.isAllowedSubtitleHost(subtitleUrl)) {
+				return undefined;
+			}
+
+			const subtitleResponse = await this.fetch(subtitleUrl.toString(), {
+				headers: {
+					'Accept': 'application/json',
+					'User-Agent': 'Mozilla/5.0 (compatible; Defuddle/1.0)',
+				},
+				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			});
+			if (!subtitleResponse.ok) {
+				return undefined;
+			}
+			const subtitleJson = await subtitleResponse.json() as SubtitleJson;
+			const transcript = this.parseSubtitleJson(subtitleJson);
+			if (!transcript) {
+				return undefined;
+			}
+			return { ...transcript, languageCode: picked.lan };
+		} catch {
+			return undefined;
+		}
+	}
+
+	private normalizeSubtitleUrl(url: string): URL | null {
+		try {
+			const trimmed = (url || '').trim();
+			if (!trimmed) return null;
+			// bilibili often returns protocol-relative URLs: //i0.hdslb.com/...
+			const normalized = trimmed.startsWith('//') ? `https:${trimmed}` : trimmed;
+			const parsed = new URL(normalized);
+			if (parsed.protocol !== 'https:') return null;
+			return parsed;
+		} catch {
+			return null;
+		}
+	}
+
+	private isAllowedSubtitleHost(url: URL): boolean {
+		const host = url.hostname.toLocaleLowerCase();
+		return host.endsWith('.hdslb.com') || host.endsWith('.bilibili.com');
+	}
+
+	private parseSubtitleJson(json: SubtitleJson): BuiltTranscript | undefined {
+		const lines = Array.isArray(json?.body) ? json.body : [];
+		const cleaned = lines
+			.map(l => ({
+				start: typeof l.from === 'number' ? l.from : NaN,
+				end: typeof l.to === 'number' ? l.to : (typeof l.from === 'number' ? l.from : NaN),
+				text: (l.content || '').trim(),
+			}))
+			.filter(l => Number.isFinite(l.start) && l.text.length > 0)
+			.sort((a, b) => a.start - b.start);
+
+		if (cleaned.length === 0) return undefined;
+
+		const segments = this.groupSubtitleLines(cleaned);
+		const { html, text } = buildTranscript('bilibili', segments);
+		return { html, text };
+	}
+
+	private groupSubtitleLines(lines: Array<{ start: number; end: number; text: string }>): TranscriptSegment[] {
+		const groups: TranscriptSegment[] = [];
+		let currentStart = lines[0].start;
+		let currentEnd = lines[0].end;
+		let currentText = lines[0].text;
+
+		const flush = () => {
+			const normalized = currentText.replace(/\s+/g, ' ').trim();
+			if (!normalized) return;
+			groups.push({
+				start: Math.max(0, Math.floor(currentStart)),
+				text: normalized,
+				speakerChange: groups.length > 0,
+			});
+		};
+
+		for (let i = 1; i < lines.length; i++) {
+			const line = lines[i];
+			const gap = line.start - currentEnd;
+			const span = Math.max(line.end, line.start) - currentStart;
+			const shouldSplit = gap > TRANSCRIPT_GROUP_GAP_SECONDS || span > TRANSCRIPT_MAX_GROUP_SECONDS;
+
+			if (shouldSplit) {
+				flush();
+				currentStart = line.start;
+				currentEnd = line.end;
+				currentText = line.text;
+				continue;
+			}
+
+			currentText = this.concatTranscriptText(currentText, line.text);
+			currentEnd = Math.max(currentEnd, line.end);
+		}
+
+		flush();
+		return groups;
+	}
+
+	private concatTranscriptText(prev: string, next: string): string {
+		const a = (prev || '').trimEnd();
+		const b = (next || '').trimStart();
+		if (!a) return b;
+		if (!b) return a;
+
+		const aLast = a[a.length - 1];
+		const bFirst = b[0];
+		const aHan = HAN_CHAR.test(aLast);
+		const bHan = HAN_CHAR.test(bFirst);
+		if (aHan && bHan) return a + b;
+
+		const aAlnum = /[A-Za-z0-9]$/.test(a);
+		const bAlnum = /^[A-Za-z0-9]/.test(b);
+		if (aAlnum && bAlnum) return `${a} ${b}`;
+
+		return `${a} ${b}`;
+	}
+}

--- a/tests/bilibili-transcript.test.ts
+++ b/tests/bilibili-transcript.test.ts
@@ -1,0 +1,307 @@
+import { describe, test, expect, vi } from 'vitest';
+import { BilibiliExtractor } from '../src/extractors/bilibili';
+import type { ExtractorOptions } from '../src/extractors/_base';
+import { parseDocument } from './helpers';
+
+function createExtractor(
+	html = '<html><body></body></html>',
+	url = 'https://www.bilibili.com/video/BV1nNkFBMEDS',
+	options?: ExtractorOptions,
+): BilibiliExtractor {
+	const doc = parseDocument(html, url);
+	return new BilibiliExtractor(doc, url, undefined, options);
+}
+
+describe('BilibiliExtractor — canExtract / getBvid', () => {
+	test('canExtract returns true for valid bilibili video URL', () => {
+		expect(createExtractor(undefined, 'https://www.bilibili.com/video/BV1nNkFBMEDS').canExtract()).toBe(true);
+	});
+
+	test('canExtract returns false for non-bilibili URL', () => {
+		expect(createExtractor(undefined, 'https://www.youtube.com/watch?v=test').canExtract()).toBe(false);
+	});
+
+	test('canExtract returns false for bilibili URL without BV id', () => {
+		expect(createExtractor(undefined, 'https://www.bilibili.com/').canExtract()).toBe(false);
+	});
+
+	test('getBvid extracts BV id from pathname', () => {
+		expect((createExtractor() as any).getBvid()).toBe('BV1nNkFBMEDS');
+	});
+
+	test('getBvid extracts BV id with trailing slash', () => {
+		const e = createExtractor(undefined, 'https://www.bilibili.com/video/BV1nNkFBMEDS/');
+		expect((e as any).getBvid()).toBe('BV1nNkFBMEDS');
+	});
+
+	test('getBvid returns empty for URL without BV id', () => {
+		expect((createExtractor(undefined, 'https://www.bilibili.com/bangumi/play/ep123') as any).getBvid()).toBe('');
+	});
+});
+
+describe('BilibiliExtractor — getPageNumber', () => {
+	test('defaults to page 1', () => {
+		expect((createExtractor() as any).getPageNumber()).toBe(1);
+	});
+
+	test('extracts page number from ?p=2', () => {
+		expect((createExtractor(undefined, 'https://www.bilibili.com/video/BV1nNkFBMEDS?p=2') as any).getPageNumber()).toBe(2);
+	});
+
+	test('clamps invalid page numbers to 1', () => {
+		expect((createExtractor(undefined, 'https://www.bilibili.com/video/BV1nNkFBMEDS?p=0') as any).getPageNumber()).toBe(1);
+		expect((createExtractor(undefined, 'https://www.bilibili.com/video/BV1nNkFBMEDS?p=-1') as any).getPageNumber()).toBe(1);
+		expect((createExtractor(undefined, 'https://www.bilibili.com/video/BV1nNkFBMEDS?p=abc') as any).getPageNumber()).toBe(1);
+	});
+});
+
+describe('BilibiliExtractor — normalizeSubtitleUrl', () => {
+	test('normalizes protocol-relative URL', () => {
+		const r = (createExtractor() as any).normalizeSubtitleUrl('//i0.hdslb.com/bfs/subtitle/foo.json');
+		expect(r).not.toBeNull();
+		expect(r.href).toBe('https://i0.hdslb.com/bfs/subtitle/foo.json');
+	});
+
+	test('accepts https URL', () => {
+		const r = (createExtractor() as any).normalizeSubtitleUrl('https://aisubtitle.hdslb.com/bfs/ai_subtitle/prod/123');
+		expect(r).not.toBeNull();
+		expect(r.protocol).toBe('https:');
+	});
+
+	test('rejects http URL', () => {
+		expect((createExtractor() as any).normalizeSubtitleUrl('http://i0.hdslb.com/bfs/subtitle/foo.json')).toBeNull();
+	});
+
+	test('returns null for empty/whitespace', () => {
+		expect((createExtractor() as any).normalizeSubtitleUrl('')).toBeNull();
+		expect((createExtractor() as any).normalizeSubtitleUrl('   ')).toBeNull();
+	});
+
+	test('returns null for invalid URL', () => {
+		expect((createExtractor() as any).normalizeSubtitleUrl('not a url')).toBeNull();
+	});
+});
+
+describe('BilibiliExtractor — isAllowedSubtitleHost', () => {
+	test('allows .hdslb.com hosts', () => {
+		expect((createExtractor() as any).isAllowedSubtitleHost(new URL('https://i0.hdslb.com/bfs/subtitle/foo.json'))).toBe(true);
+	});
+
+	test('allows .bilibili.com hosts', () => {
+		expect((createExtractor() as any).isAllowedSubtitleHost(new URL('https://api.bilibili.com/x/v2/subtitle'))).toBe(true);
+	});
+
+	test('rejects unrelated host', () => {
+		expect((createExtractor() as any).isAllowedSubtitleHost(new URL('https://evil.com/subtitle.json'))).toBe(false);
+	});
+});
+
+describe('BilibiliExtractor — parseSubtitleJson', () => {
+	test('parses valid subtitle JSON', () => {
+		const r = (createExtractor() as any).parseSubtitleJson({
+			body: [{ from: 0, to: 3, content: 'Hello world.' }, { from: 3, to: 6, content: 'Second line.' }],
+		});
+		expect(r).toBeDefined();
+		expect(r.text).toContain('Hello world.');
+		expect(r.html).toContain('<h2>Transcript</h2>');
+	});
+
+	test('returns undefined for empty body', () => {
+		expect((createExtractor() as any).parseSubtitleJson({ body: [] })).toBeUndefined();
+		expect((createExtractor() as any).parseSubtitleJson({})).toBeUndefined();
+	});
+
+	test('filters out lines with no text or non-numeric from', () => {
+		const r = (createExtractor() as any).parseSubtitleJson({
+			body: [{ from: 'bad', content: 'X' }, { from: 0, content: '' }, { from: 6, to: 9, content: 'Valid.' }],
+		});
+		expect(r).toBeDefined();
+		expect(r.text).toContain('Valid.');
+	});
+
+	test('sorts lines by start time', () => {
+		const r = (createExtractor() as any).parseSubtitleJson({
+			body: [{ from: 5, to: 8, content: 'Second.' }, { from: 0, to: 3, content: 'First.' }],
+		});
+		expect(r.text.split('\n')[0]).toContain('First.');
+	});
+});
+
+describe('BilibiliExtractor — concatTranscriptText', () => {
+	test('joins CJK without space', () => {
+		expect((createExtractor() as any).concatTranscriptText('你好', '世界')).toBe('你好世界');
+	});
+	test('joins alphanumeric with space', () => {
+		expect((createExtractor() as any).concatTranscriptText('hello', 'world')).toBe('hello world');
+	});
+	test('handles empty strings', () => {
+		expect((createExtractor() as any).concatTranscriptText('', 'hello')).toBe('hello');
+		expect((createExtractor() as any).concatTranscriptText('hello', '')).toBe('hello');
+	});
+});
+
+describe('BilibiliExtractor — groupSubtitleLines', () => {
+	test('groups adjacent lines within gap threshold', () => {
+		const groups = (createExtractor() as any).groupSubtitleLines([
+			{ start: 0, end: 3, text: 'Hello' }, { start: 3, end: 6, text: 'world.' },
+		]);
+		expect(groups).toHaveLength(1);
+		expect(groups[0].text).toBe('Hello world.');
+	});
+
+	test('splits on long gap', () => {
+		const groups = (createExtractor() as any).groupSubtitleLines([
+			{ start: 0, end: 3, text: 'First.' }, { start: 30, end: 33, text: 'Second.' },
+		]);
+		expect(groups).toHaveLength(2);
+		expect(groups[1].speakerChange).toBe(true);
+	});
+
+	test('splits when group exceeds max duration', () => {
+		const lines = Array.from({ length: 16 }, (_, i) => ({ start: i * 2, end: i * 2 + 2, text: `Line ${i}.` }));
+		const groups = (createExtractor() as any).groupSubtitleLines(lines);
+		expect(groups.length).toBeGreaterThan(1);
+	});
+});
+
+describe('BilibiliExtractor — pickSubtitleTrack', () => {
+	test('prefers zh-cn when no preference', () => {
+		const picked = (createExtractor() as any).pickSubtitleTrack([
+			{ lan: 'en', subtitle_url: 'https://i0.hdslb.com/en.json', id: 1 },
+			{ lan: 'zh-cn', subtitle_url: 'https://i0.hdslb.com/zh.json', id: 2 },
+		]);
+		expect(picked.lan).toBe('zh-cn');
+	});
+
+	test('prefers human over AI subtitle', () => {
+		const picked = (createExtractor() as any).pickSubtitleTrack([
+			{ lan: 'zh-cn', subtitle_url: 'https://i0.hdslb.com/ai.json', id: 1, is_ai_subtitle: true },
+			{ lan: 'zh-cn', subtitle_url: 'https://i0.hdslb.com/human.json', id: 2, is_ai_subtitle: false },
+		]);
+		expect(picked.id).toBe(2);
+	});
+
+	test('respects explicit language preference', () => {
+		const e = createExtractor(undefined, undefined, { language: 'en' });
+		const picked = (e as any).pickSubtitleTrack([
+			{ lan: 'zh-cn', subtitle_url: 'https://i0.hdslb.com/zh.json', id: 1 },
+			{ lan: 'en', subtitle_url: 'https://i0.hdslb.com/en.json', id: 2 },
+		], (e as any).normalizeLanguageCode((e as any).options.language));
+		expect(picked.lan).toBe('en');
+	});
+
+	test('falls back to base language match', () => {
+		const e = createExtractor(undefined, undefined, { language: 'zh-TW' });
+		const picked = (e as any).pickSubtitleTrack([
+			{ lan: 'en', subtitle_url: 'https://i0.hdslb.com/en.json', id: 1 },
+			{ lan: 'zh-cn', subtitle_url: 'https://i0.hdslb.com/zh.json', id: 2 },
+		], (e as any).normalizeLanguageCode((e as any).options.language));
+		expect(picked.lan).toBe('zh-cn');
+	});
+
+	test('returns undefined for empty tracks', () => {
+		expect((createExtractor() as any).pickSubtitleTrack([])).toBeUndefined();
+	});
+
+	test('detects AI from lan_doc', () => {
+		const picked = (createExtractor() as any).pickSubtitleTrack([
+			{ lan: 'zh-cn', subtitle_url: 'https://i0.hdslb.com/ai.json', lan_doc: '中文（AI生成）', id: 1 },
+			{ lan: 'zh-cn', subtitle_url: 'https://i0.hdslb.com/human.json', lan_doc: '中文', id: 2 },
+		]);
+		expect(picked.id).toBe(2);
+	});
+});
+
+describe('BilibiliExtractor — parseSubtitleTracks', () => {
+	test('parses from data.subtitle.subtitles', () => {
+		const tracks = (createExtractor() as any).parseSubtitleTracks({
+			data: { subtitle: { subtitles: [{ lan: 'zh-cn', subtitle_url: 'https://i0.hdslb.com/zh.json', id: 1 }] } },
+		});
+		expect(tracks).toHaveLength(1);
+		expect(tracks[0].lan).toBe('zh-cn');
+	});
+
+	test('parses from data.subtitle.list', () => {
+		const tracks = (createExtractor() as any).parseSubtitleTracks({
+			data: { subtitle: { list: [{ lan: 'en', subtitle_url: 'https://i0.hdslb.com/en.json', id: 2 }] } },
+		});
+		expect(tracks).toHaveLength(1);
+		expect(tracks[0].lan).toBe('en');
+	});
+
+	test('returns empty for missing data', () => {
+		expect((createExtractor() as any).parseSubtitleTracks({})).toEqual([]);
+	});
+
+	test('filters out tracks without lan or subtitle_url', () => {
+		const tracks = (createExtractor() as any).parseSubtitleTracks({
+			data: { subtitle: { subtitles: [
+				{ lan: '', subtitle_url: 'https://i0.hdslb.com/x.json' },
+				{ lan: 'zh-cn', subtitle_url: '' },
+				{ lan: 'en', subtitle_url: 'https://i0.hdslb.com/en.json', id: 3 },
+			] } },
+		});
+		expect(tracks).toHaveLength(1);
+		expect(tracks[0].lan).toBe('en');
+	});
+});
+
+describe('BilibiliExtractor — extractAsync', () => {
+	test('returns result with transcript from mocked API', async () => {
+		const e = createExtractor();
+		(e as any).fetchViewData = vi.fn().mockResolvedValue({
+			bvid: 'BV1nNkFBMEDS', aid: 123, title: 'Test Video', desc: 'Desc',
+			pic: 'https://i0.hdslb.com/cover.jpg', pubdate: 1700000000,
+			owner: { name: 'TestAuthor' },
+			pages: [{ cid: 456, page: 1, part: 'Part 1', duration: 120 }],
+		});
+		(e as any).fetchTranscript = vi.fn().mockResolvedValue({
+			html: '<div class="bilibili transcript"><h2>Transcript</h2><p class="transcript-segment"><strong><span class="timestamp" data-timestamp="0">0:00</span></strong> · 你好世界</p></div>',
+			text: '**0:00** · 你好世界',
+			languageCode: 'zh-cn',
+		});
+
+		const result = await e.extractAsync();
+		expect(result.variables!.title).toBe('Test Video');
+		expect(result.variables!.author).toBe('TestAuthor');
+		expect(result.variables!.site).toBe('Bilibili');
+		expect(result.variables!.transcript).toContain('你好世界');
+		expect(result.variables!.language).toBe('zh-cn');
+		expect(result.content).toContain('<iframe');
+		expect(result.content).toContain('player.bilibili.com');
+	});
+
+	test('returns result without transcript when no tracks', async () => {
+		// Clear static cache to avoid leakage from previous tests
+		(BilibiliExtractor as any).transcriptCache.clear();
+		const e = createExtractor(undefined, 'https://www.bilibili.com/video/BV1DIFFERENT');
+		(e as any).fetchViewData = vi.fn().mockResolvedValue({
+			bvid: 'BV1DIFFERENT', aid: 999, title: 'No Sub', owner: { name: 'Auth' },
+			pages: [{ cid: 789, page: 1 }],
+		});
+		(e as any).fetchPlayerV2 = vi.fn().mockResolvedValue({ tracks: [], code: 0 });
+
+		const result = await e.extractAsync();
+		expect(result.variables!.title).toBe('No Sub');
+		expect(result.variables!.transcript).toBeUndefined();
+	});
+
+	test('returns empty result when fetchViewData fails', async () => {
+		const e = createExtractor();
+		(e as any).fetchViewData = vi.fn().mockResolvedValue(undefined);
+
+		const result = await e.extractAsync();
+		expect(result.variables!.title).toBeFalsy();
+		expect(result.variables!.transcript).toBeUndefined();
+	});
+
+	test('prefersAsync returns true', () => {
+		expect(createExtractor().prefersAsync()).toBe(true);
+	});
+
+	test('extract returns result without transcript (sync path)', () => {
+		const result = createExtractor().extract();
+		expect(result).toBeDefined();
+		expect(result.content).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds subtitle (transcript) extraction support for Bilibili video pages, following the same pattern as the existing YoutubeExtractor.

## What it does

When a user visits a Bilibili video page (e.g. bilibili.com/video/BV...), the extractor now:

- Fetches video metadata (title, author, description, publish date, cover image) via the Bilibili view API
- Discovers available subtitle tracks via the player/v2 and player/wbi/v2 APIs (tries multiple endpoints for robustness)
- Selects the best subtitle track based on language preference and track quality (prefers human-authored over AI-generated, respects zh-cn > zh > en fallback order)
- Downloads and parses the subtitle JSON into a structured transcript, with intelligent line grouping (merges short adjacent lines, splits on long pauses) and CJK-aware text concatenation
- Exposes the transcript as a transcript variable (alongside title, author, site, image, published, description, part, language) for downstream consumers like Obsidian Web Clipper

## Screenshot

Transcript successfully extracted from a Bilibili video page, visible in the clipper's page variables:

<img width="1711" height="767" alt="image" src="https://github.com/user-attachments/assets/b3856a9a-9cf5-4787-833a-343b9174a294" />

## Files changed

- src/extractors/bilibili.ts — New BilibiliExtractor class with async transcript extraction, subtitle track discovery/selection, URL validation (restricted to .hdslb.com / .bilibili.com hosts), and an in-memory LRU transcript cache
- src/extractor-registry.ts — Register BilibiliExtractor for bilibili.com URL patterns

## Design notes

- Follows the existing extractor conventions: extends BaseExtractor, implements canExtract / extractAsync / prefersAsync
- Reuses the shared buildTranscript utility for consistent HTML/text output
- Subtitle content fetch omits credentials: include because the Bilibili subtitle CDN (aisubtitle.hdslb.com) returns Access-Control-Allow-Origin: *, which is incompatible with credentialed requests; the URL already carries an auth_key parameter for authorization
- Supports multi-page videos (respects the ?p= URL parameter)
- Protocol-relative subtitle URLs (//i0.hdslb.com/...) are normalized to https://



