### PR TITLE
CLI: Add --user-agent flag for fetched URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ npx defuddle parse page.html --output result.html
 
 # Enable debug mode
 npx defuddle parse page.html --debug
+
+# Use a custom User-Agent (helps with sites that return 403 to the default UA)
+npx defuddle parse https://example.com/article --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
 ```
 
 #### CLI Options
@@ -101,6 +104,7 @@ npx defuddle parse page.html --debug
 | `--property <name>` | `-p` | Extract a specific property (e.g., title, description, domain) |
 | `--debug` | | Enable debug mode |
 | `--lang <code>` | `-l` | Preferred language (BCP 47, e.g. `en`, `fr`, `ja`) |
+| `--user-agent <string>` | `-u` | Custom `User-Agent` header for HTTP requests (helps with 403/FORBIDDEN responses) |
 
 ## Installation
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ interface ParseOptions {
 	debug?: boolean;
 	property?: string;
 	lang?: string;
+	userAgent?: string;
 }
 
 // ANSI color helpers (avoids chalk dependency which is ESM-only)
@@ -46,6 +47,7 @@ program
 	.option('-p, --property <name>', 'Extract a specific property (e.g., title, description, domain)')
 	.option('--debug', 'Enable debug mode')
 	.option('-l, --lang <code>', 'Preferred language (BCP 47, e.g. en, fr, ja)')
+	.option('-u, --user-agent <string>', 'Custom User-Agent header for HTTP requests (helps with 403/FORBIDDEN responses)')
 	.action(async (source: string, options: ParseOptions) => {
 		try {
 			// Handle --md alias
@@ -67,7 +69,7 @@ program
 			const isUrl = source.startsWith('http://') || source.startsWith('https://');
 			if (isUrl) {
 				url = source;
-				const initialUA = getInitialUA(source);
+				const initialUA = options.userAgent || getInitialUA(source);
 				html = await fetchPage(source, initialUA, options.lang);
 			} else {
 				const filePath = resolve(process.cwd(), source);
@@ -79,7 +81,8 @@ program
 
 			// If no content was extracted from a URL, retry with bot UA.
 			// Some sites (e.g. Obsidian Publish) serve pre-rendered content to bots.
-			if (isUrl && result.wordCount === 0) {
+			// Skipped when the user explicitly set a UA — respect their choice.
+			if (isUrl && result.wordCount === 0 && !options.userAgent) {
 				try {
 					const botHtml = await fetchPage(source, BOT_UA, options.lang);
 


### PR DESCRIPTION
## Summary

- Adds a `--user-agent` / `-u` flag to `defuddle parse` so users can override the `User-Agent` sent when fetching a URL. The default UA (`Mozilla/5.0 (compatible; Defuddle/1.0; +https://defuddle.md)`) gets 403/FORBIDDEN from a number of sites; this gives an easy escape hatch without touching the library.
- When the flag is set, the existing "retry with bot UA on empty result" fallback is skipped — if a user picked a UA, we should respect that choice rather than silently swap it.
- README updated: new option in the CLI options table and a usage example.

Example:

```bash
npx defuddle parse https://example.com/article \
  --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
```

The plumbing was already there — `fetchPage(targetUrl, userAgent, language?)` in `src/fetch.ts` already takes a UA — this just surfaces it through the CLI.

## Test plan

- [x] `npm run build` succeeds
- [x] `node dist/cli.js parse <url> --user-agent "<ua>"` uses the supplied UA (verifiable with a request bin / `httpbin.org/user-agent`)
- [ ] `node dist/cli.js parse <url>` without the flag still uses the default UA (existing behavior unchanged)
- [ ] `--help` shows the new option

🤖 Generated with [Claude Code](https://claude.com/claude-code)