### PR TITLE
Encapsulate links with spaces

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -41,6 +41,16 @@ export function asGenericElement(node: any): GenericElement {
 const WIDTH_DESCRIPTOR_RE = /^(\d+)w,?$/;
 const DENSITY_DESCRIPTOR_RE = /^\d+(?:\.\d+)?x,?$/;
 
+function formatMarkdownLinkDestination(href: string): string {
+	if (!/\s/.test(href)) return href.replace(/([()])/g, '\\$1');
+	return `<${href.replace(/>/g, '\\>')}>`;
+}
+
+function formatMarkdownLinkTitle(title: string | null): string {
+	if (!title) return '';
+	return ` "${title.replace(/(\n+\s*)+/g, '\n').replace(/"/g, '\\"')}"`;
+}
+
 function getBestImageSrc(node: GenericElement): string {
 	const srcset = node.getAttribute('srcset');
 	if (srcset) {
@@ -392,6 +402,18 @@ export function createMarkdownContent(content: string, url: string) {
 		}
 	});
 
+	turndownService.addRule('link', {
+		filter: 'a',
+		replacement: function(content, node) {
+			if (!isGenericElement(node)) return content;
+			const href = node.getAttribute('href');
+			if (!href) return content;
+			const title = formatMarkdownLinkTitle(node.getAttribute('title'));
+			const destination = formatMarkdownLinkDestination(href);
+			return `[${content}](${destination}${title})`;
+		}
+	});
+
 	// Add a new custom rule for complex link structures
 	turndownService.addRule('complexLinkStructure', {
 		filter: function (node, options) {
@@ -421,10 +443,7 @@ export function createMarkdownContent(content: string, url: string) {
 			// Construct the new markdown
 			let markdown = `${headingContent}\n\n${remainingContent}\n\n`;
 			if (href) {
-				markdown += `[View original](${href})`;
-				if (title) {
-					markdown += ` "${title}"`;
-				}
+				markdown += `[View original](${formatMarkdownLinkDestination(href)}${formatMarkdownLinkTitle(title)})`;
 			}
 			
 			return markdown;

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,8 +1,47 @@
 import { describe, test, expect } from 'vitest';
+import { createMarkdownContent } from '../src/markdown';
 import { Defuddle } from '../src/node';
 import { parseDocument } from './helpers';
 
 describe('Markdown conversion', () => {
+	describe('links with spaces', () => {
+		test('should wrap link destinations containing spaces in angle brackets', () => {
+			const markdown = createMarkdownContent(
+				'<article><p><a href="myapp:open shared page">Open page</a></p></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('[Open page](<myapp:open shared page>)');
+		});
+
+		test('should keep normal link destinations unchanged', () => {
+			const markdown = createMarkdownContent(
+				'<article><p><a href="https://example.com/page">Open page</a></p></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('[Open page](https://example.com/page)');
+		});
+
+		test('should preserve existing parenthesis escaping for normal link destinations', () => {
+			const markdown = createMarkdownContent(
+				'<article><p><a href="https://example.com/page(1)">Open page</a></p></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('[Open page](https://example.com/page\\(1\\))');
+		});
+
+		test('should preserve titles on link destinations containing spaces', () => {
+			const markdown = createMarkdownContent(
+				'<article><p><a href="myapp:open shared page" title="Shared page">Open page</a></p></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('[Open page](<myapp:open shared page> "Shared page")');
+		});
+	});
+
 	describe('exclamation mark before image', () => {
 		test('should add space between ! and image syntax', async () => {
 			const html = `<html><head><title>Test</title></head><body><article><p>Yey!<img src="https://example.com/img.png" alt="IMG"></p></article></body></html>`;


### PR DESCRIPTION
**Summary**
Wrap Markdown link destinations containing whitespace in angle brackets so Obsidian parses them correctly
Preserving the existing normal link behavior (parenthesis escaping and title handling), let me know if anything else is missed.
Added regression coverage for spaced link destinations and existing link formatting cases

**Testing**
npm test -- tests/markdown.test.ts
npm test

Closes #275 