### PR TITLE
fix: prevent adding space on styling bold

### DIFF
--- a/src/standardize.ts
+++ b/src/standardize.ts
@@ -1191,6 +1191,8 @@ function removeEmptyLines(element: Element, doc: Document): void {
 					// 1. Next content starts with punctuation or closing parenthesis
 					// 2. Current content ends with punctuation or opening parenthesis
 					// 3. There's already a space
+					// 4. Current is a <strong> tag and BOTH sides are word characters
+					//    This avoids inserting spaces inside words split across inline tags for styling
 					const nextStartsWithPunctuation = nextContent.match(/^[,.!?:;)\]]/);
 					const currentEndsWithPunctuation = currentContent.match(/[,.!?:;(\[]\s*$/);
 					
@@ -1199,10 +1201,20 @@ function removeEmptyLines(element: Element, doc: Document): void {
 									(isTextNode(next) && 
 									(next.textContent || '').startsWith(' '));
 					
+					// Check word-character boundaries at strong element boundaries
+					// Avoids inserting spaces inside words split across styling tags
+					const currentLastIsAlnum = currentContent.match(/[\p{L}\p{N}]$/u);
+					const nextFirstIsAlnum = nextContent.match(/^[\p{L}\p{N}]/u);
+					const skipForStrongBoundary = (currentLastIsAlnum && nextFirstIsAlnum) && (
+						(isElement(current) && current.tagName.toLowerCase() === 'strong') ||
+						(isElement(next) && next.tagName.toLowerCase() === 'strong')
+					);
+					
 					// Only add space if none of the above conditions are true
 					if (!nextStartsWithPunctuation && 
 						!currentEndsWithPunctuation && 
-						!hasSpace) {
+						!hasSpace &&
+						!skipForStrongBoundary) {
 						const space = doc.createTextNode(' ');
 						node.insertBefore(space, next);
 					}


### PR DESCRIPTION
#288 pointed out a spacing issue related to `<strong>` tags conversion, which introduce extra spaces breaking up words that are partially bold for styling reasons.

#### Example
https://eblog.fly.dev/ginbad.html#3-http-is-not-that-complicated-a-brief-review
The **H**yper**T**ext **T**ransport **P**rotocol has a **client** send HTTP **Requests**, and a **server** responds with HTTP **Responses**.
gets parsed as:
The **H** yper **T** ext **T** ransport **P** rotocol has a **client** send HTTP **Requests**, and a **server** responds with HTTP **Responses**.

#### Fix
The proposed change prevent spaces from being inserted inside words that are split across `<strong>` tags, which could otherwise break up styled text incorrectly.

Fixes #288 