### PR TITLE
fix: preserve trailing columns in ragged tables

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -143,13 +143,13 @@ export function createMarkdownContent(content: string, url: string) {
 				: Array.from(node.querySelectorAll('tr')).filter(
 					(tr: any) => isDirectTableChild(tr, node)
 				);
-			const rows = rowElements.map((row: any) => {
+			const rows: string[][] = rowElements.map((row: any) => {
 				const cellElements: any[] = row.cells && row.cells.length > 0
 					? Array.from(row.cells)
 					: Array.from(row.querySelectorAll('td, th')).filter(
 						(cell: any) => cell.parentNode === row
 					);
-				const cellContents = cellElements.map((cell: any) => {
+				return cellElements.map((cell: any) => {
 					// Remove newlines and trim the content
 					let cellContent = turndownService.turndown(serializeHTML(cell))
 						.replace(/\n/g, ' ')
@@ -158,16 +158,34 @@ export function createMarkdownContent(content: string, url: string) {
 					cellContent = cellContent.replace(/\|/g, '\\|');
 					return cellContent;
 				});
-				return `| ${cellContents.join(' | ')} |`;
 			});
 
 			if (!rows.length) return content;
 
-			// Create the separator row
-			const separatorRow = `| ${Array(rows[0].split('|').length - 2).fill('---').join(' | ')} |`;
+			// A markdown table's width is fixed by its separator row; parsers
+			// drop body cells beyond it and pad rows that fall short. Source
+			// tables can be ragged, so size every row to the widest one. This
+			// preserves trailing columns the old "use row 0" logic dropped, and
+			// counting cell elements (not splitting the rendered string on '|')
+			// avoids miscounting escaped pipes inside cell content.
+			const columnCount = Math.max(...rows.map(r => r.length));
+			if (columnCount === 0) return content;
+
+			const formatRow = (cells: string[]): string => {
+				const padded = cells.length < columnCount
+					? [...cells, ...Array(columnCount - cells.length).fill('')]
+					: cells;
+				return `| ${padded.join(' | ')} |`;
+			};
+
+			const separatorRow = `| ${Array(columnCount).fill('---').join(' | ')} |`;
 
 			// Combine all rows
-			const tableContent = [rows[0], separatorRow, ...rows.slice(1)].join('\n');
+			const tableContent = [
+				formatRow(rows[0]),
+				separatorRow,
+				...rows.slice(1).map(formatRow)
+			].join('\n');
 
 			return `\n\n${tableContent}\n\n`;
 		}

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -68,4 +68,71 @@ describe('Markdown conversion', () => {
 			expect(result.contentMarkdown).toContain('longword');
 		});
 	});
+
+	describe('ragged table columns', () => {
+		test('should preserve trailing columns when body rows are wider than header', async () => {
+			const html = `<html><head><title>Test</title></head><body><article>
+				<table>
+					<tr><th>A</th><th>B</th></tr>
+					<tr><td>1</td><td>2</td><td>3</td></tr>
+					<tr><td>4</td><td>5</td><td>6</td></tr>
+				</table>
+			</article></body></html>`;
+			const result = await Defuddle(parseDocument(html, 'https://example.com'), 'https://example.com', { separateMarkdown: true });
+
+			// The table should expand to 3 columns, padding the header with an empty cell
+			expect(result.contentMarkdown).toContain('| A | B |  |');
+			expect(result.contentMarkdown).toContain('| --- | --- | --- |');
+			expect(result.contentMarkdown).toContain('| 1 | 2 | 3 |');
+			expect(result.contentMarkdown).toContain('| 4 | 5 | 6 |');
+		});
+
+		test('should pad short rows when header is wider than body', async () => {
+			const html = `<html><head><title>Test</title></head><body><article>
+				<table>
+					<tr><th>A</th><th>B</th><th>C</th></tr>
+					<tr><td>1</td><td>2</td></tr>
+					<tr><td>3</td></tr>
+				</table>
+			</article></body></html>`;
+			const result = await Defuddle(parseDocument(html, 'https://example.com'), 'https://example.com', { separateMarkdown: true });
+
+			// Short rows should be padded with empty cells
+			expect(result.contentMarkdown).toContain('| A | B | C |');
+			expect(result.contentMarkdown).toContain('| --- | --- | --- |');
+			expect(result.contentMarkdown).toContain('| 1 | 2 |  |');
+			expect(result.contentMarkdown).toContain('| 3 |  |  |');
+		});
+
+		test('should handle tables starting with an empty or narrow row', async () => {
+			const html = `<html><head><title>Test</title></head><body><article>
+				<table>
+					<tr><th></th></tr>
+					<tr><td>1</td><td>2</td></tr>
+				</table>
+			</article></body></html>`;
+			const result = await Defuddle(parseDocument(html, 'https://example.com'), 'https://example.com', { separateMarkdown: true });
+
+			// The first row should be padded to match the widest row
+			expect(result.contentMarkdown).toContain('|  |  |');
+			expect(result.contentMarkdown).toContain('| --- | --- |');
+			expect(result.contentMarkdown).toContain('| 1 | 2 |');
+		});
+
+		test('should not miscount columns when cells contain escaped pipes', async () => {
+			const html = `<html><head><title>Test</title></head><body><article>
+				<table>
+					<tr><th>Operator</th><th>Example</th></tr>
+					<tr><td>OR</td><td>A | B</td></tr>
+				</table>
+			</article></body></html>`;
+			const result = await Defuddle(parseDocument(html, 'https://example.com'), 'https://example.com', { separateMarkdown: true });
+
+			// The pipe inside "A | B" should be escaped, and the table should have exactly 2 columns
+			expect(result.contentMarkdown).toContain('| --- | --- |');
+			expect(result.contentMarkdown).toContain('A \\| B');
+			// Should NOT have 3 or more separator columns
+			expect(result.contentMarkdown).not.toContain('| --- | --- | --- |');
+		});
+	});
 });


### PR DESCRIPTION
## Summary
Tables with unequal row widths (e.g., header narrower than body rows) were producing malformed markdown where the separator row's column count was derived solely from the first row, causing parsers to silently drop trailing cells or misalign content.

## Root Causes
1. **Separator width calculated via `rows[0].split('|').length - 2`** — only looks at the first row, so wider rows later lose data.
2. **String-based column counting** — escaped pipes (`\|`) inside cell content are miscounted as column delimiters.
3. **No padding/expansion logic** — rows shorter than the separator are left ragged; rows wider than it are truncated.

## Changes
- Derive column count from the **widest row** (`Math.max(...rows.map(r => r.length))`) instead of the first row.
- Pad every row (including the header) to that width with empty cells.
- Count **cell elements** directly instead of splitting the rendered string, avoiding the escaped-pipe miscount.

## Result
GFM-compliant tables that preserve all source data across ragged inputs.

## Test Coverage
Added 4 regression tests in `tests/markdown.test.ts`:
- Header narrower than body (trailing columns previously dropped)
- Header wider than body (short rows now padded)
- Empty/narrow first row (no longer forces 1-column output)
- Escaped pipes in cell content (no longer miscounted)

All 285 existing tests pass.