### PR TITLE
Fix MathML markdown conversion for complex and aligned math

### DIFF
--- a/src/elements/math.base.ts
+++ b/src/elements/math.base.ts
@@ -77,6 +77,12 @@ export const getBasicLatexFromElement = (el: Element): string | null => {
 	if (dataMath) {
 		return dataMath;                                                                                                                                             
 	}
+	const parentDataEntry = el.parentElement?.classList.contains('hurmet-tex')
+		? el.parentElement.getAttribute('data-entry')
+		: null;
+	if (parentDataEntry) {
+		return parentDataEntry;
+	}
 	
 	// WordPress LaTeX images
 	if (el.tagName.toLowerCase() === 'img' && el.classList.contains('latex')) {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -16,10 +16,13 @@ type GenericElement = {
 		cells?: ArrayLike<{}>;
 	}>;
 	parentNode?: GenericElement | null;
+	previousSibling?: Node | null;
 	nextSibling?: GenericElement | null;
 	nodeName: string;
 	innerHTML: string;
+	outerHTML?: string;
 	children?: ArrayLike<GenericElement>;
+	childNodes?: ArrayLike<Node>;
 	cloneNode: (deep?: boolean) => Node;
 	textContent?: string | null;
 	attributes?: NamedNodeMap;
@@ -628,11 +631,13 @@ export function createMarkdownContent(content: string, url: string) {
 			if (!isInTable && (
 				node.getAttribute('display') === 'block' || 
 				node.classList?.contains('mwe-math-fallback-image-display') || 
+				isOnlyMathInParagraph(node) ||
 				(node.parentNode && isGenericElement(node.parentNode) && 
 				node.parentNode.classList?.contains('mwe-math-element') && 
 				node.parentNode.previousSibling && isGenericElement(node.parentNode.previousSibling) && 
 				node.parentNode.previousSibling.nodeName.toLowerCase() === 'p')
 			)) {
+				latex = formatBlockLatex(latex);
 				return `\n$$\n${latex}\n$$\n`;
 			} else {
 				// For inline math, ensure there's a space before and after only if needed
@@ -775,24 +780,128 @@ export function createMarkdownContent(content: string, url: string) {
 	}
 
 	function extractLatex(element: GenericElement): string {
-		let latex = element.getAttribute('data-latex');
+		const annotation = element.querySelector('annotation[encoding="application/x-tex"]');
+		if (annotation?.textContent?.trim()) {
+			return annotation.textContent.trim();
+		}
+
+		const latex = element.getAttribute('data-latex');
 		const alttext = element.getAttribute('alttext');
-		if (latex) {
+		const hasMathML = hasMathMLChildren(element);
+		const hasComplexMathML = hasComplexMathMLChildren(element);
+
+		if (latex && (!hasMathML || isTrustworthyLatexAttribute(latex, hasComplexMathML))) {
 			return latex.trim();
-		} else if (alttext) {
+		} else if (alttext && (!hasMathML || isTrustworthyLatexAttribute(alttext, hasComplexMathML))) {
 			return alttext.trim();
 		}
+
 		// Fallback: convert MathML → LaTeX for renderers like MathJax SVG that embed no LaTeX.
 		// Fails silently when mathml-to-latex is unavailable (core bundle).
-		if (element.nodeName.toLowerCase() === 'math') {
-			try {
-				const { MathMLToLaTeX } = require('mathml-to-latex');
-				return MathMLToLaTeX.convert(`<math>${element.innerHTML}</math>`).trim();
-			} catch (e) {
-				// not available or conversion failed
+		if (element.nodeName.toLowerCase() === 'math' && hasMathML) {
+			const converted = convertMathMLToLatex(element);
+			if (converted) return converted;
+		}
+
+		if (latex) return latex.trim();
+		if (alttext) return alttext.trim();
+		return '';
+	}
+
+	function hasMathMLChildren(element: GenericElement): boolean {
+		const mathMLNodeNames = new Set([
+			'annotation', 'maction', 'math', 'menclose', 'merror', 'mfenced', 'mfrac', 'mi',
+			'mmultiscripts', 'mn', 'mo', 'mover', 'mpadded', 'mphantom', 'mprescripts',
+			'mroot', 'mrow', 'ms', 'mspace', 'msqrt', 'mstyle', 'msub', 'msubsup',
+			'msup', 'mtable', 'mtd', 'mtext', 'mtr', 'munder', 'munderover', 'none',
+			'semantics'
+		]);
+
+		return Array.from(element.children || []).some(child => {
+			const namespace = (child as unknown as Element).namespaceURI;
+			return namespace === 'http://www.w3.org/1998/Math/MathML' ||
+				mathMLNodeNames.has(child.nodeName.toLowerCase());
+		});
+	}
+
+	function hasComplexMathMLChildren(element: GenericElement): boolean {
+		const complexMathMLNodeNames = new Set([
+			'menclose', 'mfrac', 'mmultiscripts', 'mover', 'mroot', 'msqrt', 'msub',
+			'msubsup', 'msup', 'mtable', 'mtd', 'mtr', 'munder', 'munderover'
+		]);
+
+		const visit = (node: GenericElement): boolean => {
+			if (complexMathMLNodeNames.has(node.nodeName.toLowerCase())) {
+				return true;
 			}
+
+			return Array.from(node.children || []).some(child => visit(child));
+		};
+
+		return visit(element);
+	}
+
+	function convertMathMLToLatex(element: GenericElement): string {
+		try {
+			const { MathMLToLaTeX } = require('mathml-to-latex');
+			const mathML = (element.outerHTML || `<math>${element.innerHTML}</math>`)
+				.replace(/&amp;nbsp;/g, '&#xA0;')
+				.replace(/&nbsp;/g, '&#xA0;');
+			return MathMLToLaTeX.convert(mathML).trim();
+		} catch (e) {
+			// not available or conversion failed
 		}
 		return '';
+	}
+
+	function isLikelyLatexSource(value: string): boolean {
+		return /\\[a-zA-Z]+|[_^{}]|[$&]|\\\\|\\begin\{/.test(value);
+	}
+
+	function isTrustworthyLatexAttribute(value: string, hasComplexMathML: boolean): boolean {
+		if (isLikelyLatexSource(value)) return true;
+
+		const trimmed = value.trim();
+		if (!trimmed) return false;
+
+		if (hasComplexMathML) return false;
+
+		// Rendered prose fragments such as "fan-outfan-in" can be written into
+		// data-latex by upstream normalizers. Keep simple symbolic text like
+		// "AB", "A, B", or "∑", but prefer MathML for hyphenated word fragments.
+		return !/[a-zA-Z]{3,}-[a-zA-Z]{2,}/.test(trimmed);
+	}
+
+	function hasLatexEnvironment(value: string): boolean {
+		return /\\begin\{[^}]+\}/.test(value);
+	}
+
+	function formatBlockLatex(value: string): string {
+		const latex = value.trim();
+		if (!latex || hasLatexEnvironment(latex)) return latex;
+
+		if (latex.includes('\\\\') || latex.includes('&')) {
+			return `\\begin{aligned}\n${latex}\n\\end{aligned}`;
+		}
+
+		return latex;
+	}
+
+	function isOnlyMathInParagraph(element: GenericElement): boolean {
+		const parent = element.parentNode;
+		if (!parent || !isGenericElement(parent) || parent.nodeName.toLowerCase() !== 'p') {
+			return false;
+		}
+
+		const elementChildren = Array.from(parent.children || []);
+		if (elementChildren.length !== 1 || elementChildren[0] !== element) {
+			return false;
+		}
+
+		const currentNode = element as unknown as Node;
+		return Array.from(parent.childNodes || []).every(child => {
+			return child === currentNode || (isTextNode(child) && child.textContent?.trim() === '');
+		});
 	}
 
 	try {

--- a/tests/expected/math--mathjax.md
+++ b/tests/expected/math--mathjax.md
@@ -22,7 +22,9 @@ $$
 ## The Lorenz Equations
 
 $$
+\begin{aligned}
 \overset{\cdot}{x} & = \sigma \left(\right. y - x \left.\right) \\ \overset{\cdot}{y} & = \rho x - y - x z \\ \overset{\cdot}{z} & = - \beta z + x y
+\end{aligned}
 $$
 
 ## The Cauchy-Schwarz Inequality
@@ -34,7 +36,9 @@ $$
 ## A Cross Product Formula
 
 $$
+\begin{aligned}
 \mathbf{V}_{1} \times \mathbf{V}_{2} = \left|\right. \mathbf{i} & \mathbf{j} & \mathbf{k} \\ \frac{\partial X}{\partial u} & \frac{\partial Y}{\partial u} & 0 \\ \frac{\partial X}{\partial v} & \frac{\partial Y}{\partial v} & 0 \left|\right.
+\end{aligned}
 $$
 
 ## The probability of getting
@@ -59,7 +63,9 @@ $$
 ## Maxwell's Equations
 
 $$
+\begin{aligned}
 \nabla \times \overset{\rightarrow}{\mathbf{B}} - \frac{1}{c} \frac{\partial \overset{\rightarrow}{\mathbf{E}}}{\partial t} & = \frac{4 \pi}{c} \overset{\rightarrow}{\mathbf{j}} \\ \nabla \cdot \overset{\rightarrow}{\mathbf{E}} & = 4 \pi \rho \\ \nabla \times \overset{\rightarrow}{\mathbf{E}} + \frac{1}{c} \frac{\partial \overset{\rightarrow}{\mathbf{B}}}{\partial t} & = \overset{\rightarrow}{0} \\ \nabla \cdot \overset{\rightarrow}{\mathbf{B}} & = 0
+\end{aligned}
 $$
 
 ## In-line Mathematics

--- a/tests/expected/math--temml.md
+++ b/tests/expected/math--temml.md
@@ -11,34 +11,34 @@ A variety of Temml-rendered math elements using the `hurmet-tex` pattern.
 
 ## Accents
 
-| $F→$ `\vec{F}` | $a~$ `\tilde{a}` | $θ^$ `\hat{\theta}` |
+| $\vec{F}$ `\vec{F}` | $\tilde{a}$ `\tilde{a}` | $\hat{\theta}$ `\hat{\theta}` |
 | --- | --- | --- |
-| $a˙$ `\dot{a}` | $AB$ `\overline{AB}` | $AB⏞$ `\overbrace{AB}` |
+| $\dot{a}$ `\dot{a}` | $\overline{AB}$ `\overline{AB}` | $\overbrace{AB}$ `\overbrace{AB}` |
 
 ## Fractions and Roots
 
-Inline fraction: $ab$ and square root: $x2+y2$.
+Inline fraction: $\frac{a}{b}$ and square root: $\sqrt{x^2+y^2}$.
 
-Cube root: $83$
+Cube root: $\sqrt[3]{8}$
 
 ## Display Math
 
 $$
-E=mc2
+E = mc^2
 $$
 
 ## Operators
 
-| $∑$ `\sum` | $∫$ `\int` | $∏$ `\prod` | $∮$ `\oint` |
+| $\sum$ `\sum` | $\int$ `\int` | $\prod$ `\prod` | $\oint$ `\oint` |
 | --- | --- | --- | --- |
 
 ## Environments
 
-| $(abcd)$ | `\begin{pmatrix}`   `a & b \\`   `c & d`   `\end{pmatrix}` |
+| $\begin{pmatrix} a & b \\ c & d \end{pmatrix}$ | `\begin{pmatrix}`   `a & b \\`   `c & d`   `\end{pmatrix}` |
 | --- | --- |
 
 ## Greek and Symbols
 
-Greek letters: $α$, $β$, $γ$, $Ω$
+Greek letters: $\alpha$, $\beta$, $\gamma$, $\Omega$
 
-Relation: $a≤b$, not equal: $x≠y$
+Relation: $a \leq b$, not equal: $x \neq y$

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -177,4 +177,121 @@ describe('Markdown conversion', () => {
 			expect(result.contentMarkdown).not.toContain('| --- | --- | --- |');
 		});
 	});
+
+	describe('math conversion', () => {
+		test('should prefer MathML over degraded data-latex', () => {
+			const markdown = createMarkdownContent(`
+				<p>
+					Test
+					<math data-latex="fan-outfan-in">
+						<mrow>
+							<msqrt><mi>x</mi></msqrt>
+							<mo>&#x2190;</mo>
+							<mi>y</mi>
+						</mrow>
+					</math>
+				</p>
+			`, 'https://example.com');
+
+			expect(markdown).toContain('\\sqrt');
+			expect(markdown).toContain('\\leftarrow');
+			expect(markdown).not.toContain('fan-outfan-in');
+		});
+
+		test('should prefer complex MathML over rendered text data-latex', () => {
+			const markdown = createMarkdownContent(`
+				<p>
+					<math display="inline" data-latex="rt(θ)=πθ(at|st)πθold(at|st)">
+						<mrow>
+							<msub><mi>r</mi><mi>t</mi></msub>
+							<mo stretchy="false">(</mo><mi>θ</mi><mo stretchy="false">)</mo>
+							<mo>=</mo>
+							<mfrac>
+								<mrow>
+									<msub><mi>π</mi><mrow><mi>θ</mi></mrow></msub>
+									<mo stretchy="false">(</mo>
+									<msub><mi>a</mi><mi>t</mi></msub>
+									<mo stretchy="false">|</mo>
+									<msub><mi>s</mi><mi>t</mi></msub>
+									<mo stretchy="false">)</mo>
+								</mrow>
+								<mrow>
+									<msub>
+										<mi>π</mi>
+										<mrow><msub><mi>θ</mi><mrow><mtext>old</mtext></mrow></msub></mrow>
+									</msub>
+									<mo stretchy="false">(</mo>
+									<msub><mi>a</mi><mi>t</mi></msub>
+									<mo stretchy="false">|</mo>
+									<msub><mi>s</mi><mi>t</mi></msub>
+									<mo stretchy="false">)</mo>
+								</mrow>
+							</mfrac>
+						</mrow>
+					</math>
+				</p>
+			`, 'https://example.com');
+
+			expect(markdown).toContain('$$');
+			expect(markdown).toContain('\\frac');
+			expect(markdown).toContain('r_{t}');
+			expect(markdown).toContain('\\pi_{\\theta}');
+			expect(markdown).toContain('\\theta_{\\text{old}}');
+			expect(markdown).not.toContain('rt(θ)=πθ(at|st)πθold(at|st)');
+		});
+
+		test('should wrap block aligned MathML in an aligned environment', () => {
+			const markdown = createMarkdownContent(`
+				<p>
+					<math display="block">
+						<mtable>
+							<mtr>
+								<mtd><mi>a</mi></mtd>
+								<mtd><mo>=</mo></mtd>
+								<mtd><mi>b</mi></mtd>
+							</mtr>
+							<mtr>
+								<mtd><mi>c</mi></mtd>
+								<mtd><mo>=</mo></mtd>
+								<mtd><mi>d</mi></mtd>
+							</mtr>
+						</mtable>
+					</math>
+				</p>
+			`, 'https://example.com');
+
+			expect(markdown).toContain('$$');
+			expect(markdown).toContain('\\begin{aligned}');
+			expect(markdown).toContain('&');
+			expect(markdown).toContain('\\\\');
+			expect(markdown).toContain('\\end{aligned}');
+		});
+
+		test('should treat paragraph-only inline math as block math', () => {
+			const markdown = createMarkdownContent(`
+				<p><math display="inline" data-latex="x^2">x2</math></p>
+			`, 'https://example.com');
+
+			expect(markdown.trim()).toBe('$$\nx^2\n$$');
+		});
+
+		test('should preserve valid inline data-latex without MathML', () => {
+			const markdown = createMarkdownContent(`
+				<p>Value <math data-latex="x^2">x2</math> now.</p>
+			`, 'https://example.com');
+
+			expect(markdown).toContain('Value $x^2$ now.');
+		});
+
+		test('should not double-wrap existing LaTeX environments', () => {
+			const latex = '\\begin{align*}a&=b\\\\c&=d\\end{align*}';
+			const markdown = createMarkdownContent(`
+				<p><math data-latex="${latex}">${latex}</math></p>
+			`, 'https://example.com');
+
+			expect(markdown).toContain('\\begin{align*}');
+			expect(markdown).toContain('\\end{align*}');
+			expect(markdown).not.toContain('\\begin{aligned}');
+		});
+	});
 });


### PR DESCRIPTION
Prefer source LaTeX annotations and trustworthy
attributes, fall back to MathML conversion for
complex rendered math, wrap aligned block output
in an aligned environment, and preserve Temml
data-entry LaTeX.