### PR TITLE
Preserve heading-anchored content sections

### DIFF
--- a/src/removals/selectors.ts
+++ b/src/removals/selectors.ts
@@ -8,8 +8,65 @@ import {
 	FOOTNOTE_LIST_SELECTORS
 } from '../constants';
 import { DebugRemoval } from '../types';
-import { textPreview, logDebug } from '../utils';
+import { textPreview, logDebug, countWords } from '../utils';
 import { getClassName, hasResponsiveShowClass } from '../utils/dom';
+
+function normalizeAnchorText(text: string): string {
+	return text.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+const HEADING_ANCHOR_CLUTTER_PATTERN = /^(?:related|relatedposts?|relatedarticles?|relatedcontent|relatedstories|relatedreads?|relatedreading|furtherreading|seealso|readnext|readmore|readalso|morearticles?|moreposts?|morelikethis|recommended|recommendations|youmightalsolike|youmayalsolike|youcouldalsolike|aboutauthor|abouttheauthor|latestnews|latestevents?|latestposts?|latestarticles?|lateststories)$/;
+
+function isHeadingAnchoredContentSection(el: Element, mainContent?: Element | null): boolean {
+	if (!mainContent || !mainContent.contains(el)) {
+		return false;
+	}
+	if (!['SECTION', 'ARTICLE'].includes(el.tagName)) {
+		return false;
+	}
+
+	const id = el.id || '';
+	if (!id) {
+		return false;
+	}
+
+	const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
+	if (!heading) {
+		return false;
+	}
+
+	// Many article pages use section ids as heading permalinks. Treat those ids
+	// as anchors, not clutter signals, when the section contains real prose.
+	const normalizedHeading = normalizeAnchorText(heading.textContent || '');
+	if (HEADING_ANCHOR_CLUTTER_PATTERN.test(normalizedHeading)) {
+		return false;
+	}
+	if (normalizeAnchorText(id) !== normalizedHeading) {
+		return false;
+	}
+
+	if (!el.querySelector('p, blockquote, pre, table, figure')) {
+		return false;
+	}
+
+	return countWords(el.textContent || '') >= 15;
+}
+
+function isFigureLikeContent(el: Element, mainContent?: Element | null): boolean {
+	if (!mainContent || !mainContent.contains(el)) {
+		return false;
+	}
+	if (el.tagName === 'FIGURE') {
+		return !!el.querySelector('img, picture, video, svg');
+	}
+
+	const className = getClassName(el).toLowerCase();
+	return className.includes('figure') && !!el.querySelector('img, picture, video, svg');
+}
+
+function shouldIgnoreIdForPartialMatching(el: Element, mainContent?: Element | null): boolean {
+	return isHeadingAnchoredContentSection(el, mainContent) || isFigureLikeContent(el, mainContent);
+}
 
 export function removeBySelector(doc: Document, debug: boolean, removeExact: boolean = true, removePartial: boolean = true, mainContent?: Element | null, debugRemovals?: DebugRemoval[], skipHiddenExactSelectors: boolean = false) {
 	const startTime = Date.now();
@@ -84,10 +141,11 @@ export function removeBySelector(doc: Document, debug: boolean, removeExact: boo
 			// For headings, only check class — IDs are auto-slugs and data-testid
 			// values (e.g. "article-header") cause false positives.
 			const isHeading = /^H[1-6]$/.test(tag);
+			const useId = !isHeading && !shouldIgnoreIdForPartialMatching(el, mainContent);
 			const attrs = (isHeading
 				? getClassName(el)
 				: getClassName(el) + ' ' +
-					(el.id || '') + ' ' +
+					(useId ? (el.id || '') : '') + ' ' +
 					(el.getAttribute('data-component') || '') + ' ' +
 					(el.getAttribute('data-test') || '') + ' ' +
 					(el.getAttribute('data-testid') || '') + ' ' +

--- a/tests/expected/issues--303-martinfowler-heading-anchor-sections.md
+++ b/tests/expected/issues--303-martinfowler-heading-anchor-sections.md
@@ -1,0 +1,27 @@
+```json
+{
+  "title": "Harness engineering for coding agent users",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+The term harness has emerged as a shorthand to mean everything in an AI agent except the model itself. That is a wide definition, and this fixture narrows it to coding agents while keeping enough prose to avoid low-content retry behavior. A well-built outer harness increases the probability that the agent gets it right in the first place and provides a feedback loop that self-corrects issues before they reach human eyes.
+
+## Feedforward and Feedback
+
+To harness a coding agent we both anticipate unwanted outputs and try to prevent them, and we put sensors in place to allow the agent to self-correct after it acts.
+
+- **Guides** anticipate the agent's behaviour and aim to steer it before it acts.
+- **Sensors** observe after the agent acts and help it self-correct.
+
+## Computational vs Inferential
+
+Computational controls are deterministic and fast. Inferential controls add semantic judgment, but they are slower, more expensive, and less deterministic.
+
+![Shows examples of continuous feedback sensors after change integration.](https://martinfowler.com/articles/harness-engineering/harness-continuous-feedback-examples.png)
+
+## The role of the human
+
+Human developers bring context, accountability, taste, organisational memory, and judgment that a coding agent does not carry by default. Harnesses externalise some of that experience, but they should direct human input to where it matters most.

--- a/tests/expected/issues--303-related-heading-anchor-section.md
+++ b/tests/expected/issues--303-related-heading-anchor-section.md
@@ -1,0 +1,16 @@
+```json
+{
+  "title": "Related section selector regression",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+## Preserve Real Heading Anchors
+
+This article starts with a short explanation before an unrelated recommendations block. The recommendations block uses a heading-derived id and enough link text to look substantial, but it is not article prose.
+
+## Implementation Details
+
+The real article section contains prose under a heading-derived id. This is the content that should remain available after selector cleanup.

--- a/tests/fixtures/issues--303-martinfowler-heading-anchor-sections.html
+++ b/tests/fixtures/issues--303-martinfowler-heading-anchor-sections.html
@@ -1,0 +1,37 @@
+<!-- {"url":"https://martinfowler.com/articles/harness-engineering.html"} -->
+<!doctype html>
+<html>
+<head>
+	<title>Harness engineering for coding agent users</title>
+</head>
+<body>
+	<main>
+		<div class="paperBody deep">
+			<p>The term harness has emerged as a shorthand to mean everything in an AI agent except the model itself. That is a wide definition, and this fixture narrows it to coding agents while keeping enough prose to avoid low-content retry behavior. A well-built outer harness increases the probability that the agent gets it right in the first place and provides a feedback loop that self-corrects issues before they reach human eyes.</p>
+
+			<section id="FeedforwardAndFeedback">
+				<h2>Feedforward and Feedback</h2>
+				<p>To harness a coding agent we both anticipate unwanted outputs and try to prevent them, and we put sensors in place to allow the agent to self-correct after it acts.</p>
+				<ul>
+					<li><b>Guides</b> anticipate the agent's behaviour and aim to steer it before it acts.</li>
+					<li><b>Sensors</b> observe after the agent acts and help it self-correct.</li>
+				</ul>
+			</section>
+
+			<section id="ComputationalVsInferential">
+				<h2>Computational vs Inferential</h2>
+				<p>Computational controls are deterministic and fast. Inferential controls add semantic judgment, but they are slower, more expensive, and less deterministic.</p>
+			</section>
+
+			<div class="figure" id="harness-continuous-feedback-examples.png">
+				<img alt="Shows examples of continuous feedback sensors after change integration." src="harness-engineering/harness-continuous-feedback-examples.png">
+			</div>
+
+			<section id="TheRoleOfTheHuman">
+				<h2>The role of the human</h2>
+				<p>Human developers bring context, accountability, taste, organisational memory, and judgment that a coding agent does not carry by default. Harnesses externalise some of that experience, but they should direct human input to where it matters most.</p>
+			</section>
+		</div>
+	</main>
+</body>
+</html>

--- a/tests/fixtures/issues--303-related-heading-anchor-section.html
+++ b/tests/fixtures/issues--303-related-heading-anchor-section.html
@@ -1,0 +1,31 @@
+<!-- {"url":"https://example.com/heading-anchor-related-section"} -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Related section selector regression</title>
+</head>
+<body>
+  <main>
+    <article>
+      <h1>Preserve Real Heading Anchors</h1>
+
+      <p>This article starts with a short explanation before an unrelated recommendations block. The recommendations block uses a heading-derived id and enough link text to look substantial, but it is not article prose.</p>
+
+      <section id="related">
+        <h2>Related</h2>
+        <p>Recommended articles with short snippets are still site chrome, even when they contain paragraph text and look like prose-bearing sections.</p>
+        <ul>
+          <li><a href="/one">A long related article title that should not become extracted content</a><p>A snippet that would otherwise satisfy a simple prose check.</p></li>
+          <li><a href="/two">Another recommendation card title with enough words to pass simple word thresholds</a><p>A second snippet that makes this block look more article-like.</p></li>
+          <li><a href="/three">Further reading that belongs to site chrome instead of the article body</a><p>A third snippet keeps the fixture representative of recommendation blocks.</p></li>
+        </ul>
+      </section>
+
+      <section id="ImplementationDetails">
+        <h2>Implementation Details</h2>
+        <p>The real article section contains prose under a heading-derived id. This is the content that should remain available after selector cleanup.</p>
+      </section>
+    </article>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Fixes #303.

## Summary

- Avoid using heading-derived IDs as partial-selector clutter signals for semantic article sections.
- Keep known clutter headings such as `Related` and `Further reading` eligible for existing partial-selector cleanup.
- Apply the same ID-only protection to figure-like content wrappers.
- Add regression fixtures based on the Martin Fowler harness-engineering page and a related-section false-positive case.

## Validation

- `npx vitest run tests/fixtures.test.ts --testNamePattern "issues--303"`
- `npm run build`
- `npm test`
- OpenClaw autoreview: `autoreview --mode branch --base upstream/main` returned clean with no accepted/actionable findings.
- Local parse of `https://martinfowler.com/articles/harness-engineering.html` now includes:
  - `Feedforward and Feedback`
  - `The role of the human`
  - `harness-continuous-feedback-examples`
