### PR TITLE
fix: add #main to ENTRY_POINT_ELEMENTS

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export const ENTRY_POINT_ELEMENTS = [
 	'[role="article"]',
 	'main',
 	'[role="main"]',
+	'#main',
 	'.article-body',
 	'#content',
 	'body' // ensures there is always a match

--- a/tests/expected/entry-point--id-main.md
+++ b/tests/expected/entry-point--id-main.md
@@ -1,0 +1,64 @@
+```json
+{
+  "title": "Mailed in passport applications (adult renewals",
+  "author": "",
+  "site": "PC7)",
+  "published": ""
+}
+```
+
+### Eligibility
+
+For an Adult passport renewal, you must be 18 years and over and you will need a passport that:
+
+- was issued when you were aged 16 or older
+- was issued on or after 1 January 2006
+- had, when it was issued, at least two years’ validity
+- has your current name, date of birth, place of birth and gender
+- has not been reported lost, stolen, or cancelled, and
+- you are not requesting a [replacement passport](https://www.passports.gov.au/help/replacement-passport)
+
+If you can answer yes to all the above, complete your passport renewal application [online](https://online.passports.gov.au/produce/).
+
+If you don’t meet these criteria, you’ll need lodge your application in person by appointment only.
+
+[![Book an appointment with Australian Embassy Bangkok using SetMore](https://my.setmore.com/webapp/images/bookappt/SetMore-book-button.png)](https://my.setmore.com/bookingpage/4d0e8f45-23ee-4b04-a10d-ab0149192866)
+
+### For applications lodged by mail in Thailand
+
+- For mailed in passport applications, a drop off and collection service at the Embassy is NOT available
+- Please include a self-addressed envelope (either A5 or A4) for return of your completed document
+- DO NOT send any original documents, including your existing passport
+- Incomplete applications will be delayed. Common issues include:
+	- Photos that don’t meet the guidelines, are digitally altered, or have inks marks on them
+		- Signatures must be inside the declaration ‘white’ box, and application forms dated using the correct format (DD/MM/YYYY)
+		- Credit cards that are not enabled for international transactions
+- If your passport is damaged, please contact us to discuss prior to mailing in your application
+- If you are requesting a [replacement passport](https://www.passports.gov.au/help/replacement-passport) you will need to lodge in person. To book an appointment, go to our [main passports page](https://thailand.embassy.gov.au/bkok/Australian_Passports_Page.html).
+
+### Guide for Adult renewal application by mail
+
+|  | #### 1\. Complete your renewal application form online  - The application must be lodged within six months of completion |
+| --- | --- |
+| ![](https://thailand.embassy.gov.au/files/bkok/Passport%20graphic2.jpg) | #### 2\. Print and sign your application form  - **Print** on **plain white A4 paper**, using **black ink** only. Make sure the top or bottom of the page is not cut off. - US standard letter paper or US legal paper sizes are also acceptable, but only if they’re scaled properly. - **Sign** the form using **black pen**, **within the signature box.** Make sure there are no alterations or whiteout on the signature or the date. |
+|  | #### 3\. Photos  - Two recent identical colour photos, less than 6 months old with your full name written on the back of one photo. Refer to [photo guidelines](https://www.passports.gov.au/sites/default/files/2024-12/CameraOperatorGuide_A4-2025_1.pdf) for more information - Do NOT attach the photos to the form as this may damage them - Ensure ink from the endorsed photo does not transfer to the unendorsed photo  ![](https://thailand.embassy.gov.au/files/bkok/ppt%20photo%20measurement.jpg) |
+|  | #### 4\. Payment  - Complete the [payment authorisation form (PDF)](https://thailand.embassy.gov.au/files/bkok/Credit%20card%20authorisation%20form%20\(Bangkok-mar25\).pdf), include this with your application form - You can view more information on [passport fees](https://thailand.embassy.gov.au/bkok/Notarial_Service_and_Passport_Fees.html#Passport%20Fees) |
+|  | #### 5\. Check your adult renewal checklist  - Before posting your application, review your [adult renewal checklist](https://thailand.embassy.gov.au/bkok/Passports_Checklists.html#Adult%20Passport%20Renewal%20\(Single%20page%20streamlined%20renewal%20form\)) |
+|  | #### 6\. Post your application  - Post your application to the Embassy in Bangkok or Consulate-General in Phuket via the local postal system (registered post is recommended). - You **CANNOT** submit your application in person without an appointment. - Please **DO NOT** use delivery service such as Grab, LINE Man, Kerry, to submit your mailed-in application. We accept mailed-in application that comes in the Post Office mail system only.  **(Bangkok / Chiang Mai)**  Consular Services Section – Passport Services  Australian Embassy Bangkok  181 Soi Arun McKinnon  Wireless Road, Lumphini, Pathumwan  Bangkok 10330  **(Phuket)**  Consular Services Section – Passport Services  Australian Consulate-General Phuket  6th Floor, CCM Complex  77/77 Chalermprakiat Rama 9 Road (Bypass Road)  Phuket 83000  **Have you included:**  - **Your printed and signed application form** - **Passport photos** - **A self-addressed A5 or A4 envelope (postage stamps not required)** - **Completed payment authorisation form** |
+|  | #### 7\. How long will it take?  - Please allow **a minimum of six weeks** to receive a new passport once payment has been taken. **PLEASE NOTE** incomplete applications will cause delays. - We will post your new passport out to you via registered post (in-person collection is NOT available for mailed in applications) |
+
+## Questions?
+
+If you still have questions, please contact us directly to discuss before sending your application.
+
+**Bangkok** (including Chiang Mai)
+
+Telephone: +66 (0) 2 344 6300, select Consular Services option
+
+Email: \[email protected\]
+
+**Phuket**
+
+Telephone: +66 (0) 76 317 700
+
+Email: \[email protected\]

--- a/tests/fixtures/entry-point--id-main.html
+++ b/tests/fixtures/entry-point--id-main.html
@@ -1,0 +1,1382 @@
+<!-- {"url": "https://thailand.embassy.gov.au/bkok/Mailed_in_passport_applications.html"} -->
+<!DOCTYPE html >
+<html lang="" dir="ltr">
+
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+<meta name="DC.Identifier" scheme="URI" content="http://www.xxx.embassy.gov.au/index.html" />
+<meta name="DC.Creator" content="corporateName= Department of Foreign Affairs and Trade" />
+<meta name="DC.Publisher" content="corporateName= Department of Foreign Affairs and Trade" />
+<meta name="DC.Rights" content="Copyright Commonwealth of Australia 2005" />
+<meta name="DC.Title" content="Australian Embassy in " />
+<meta name="DC.Subject" scheme="APAIS" content="Mailed_in_passport_applications" />
+<meta name="DC.Language" scheme="RFC1766" content="" />
+<meta name="DC.Coverage.jurisdiction" content="Australia" />
+<meta name="AGLS.Function" scheme="AGIFT" content="Consular Services; Diplomatic missions; International affairs; international liaison; International treaty participation; Overseas promotion; Passport services; International trade agreements; Trade development programs; information dissemination" />
+<meta name="DC.Date.created" scheme="ISO8601" content="01/10/2005" />
+<meta name="DC.Type.aggregationLevel" content="Collection" />
+<meta name="DC.Type.documentType" scheme="agls-document" content="Mailed_in_passport_applications" />
+<meta name="DC.Format" scheme="IMT" content="text/html" />
+<meta name="revisit-after" content="2 Days" />
+<meta name="Robot" content="ALL" />
+<meta name="rating" content="General" />
+<meta name="langid-exists" content="true" />
+<meta name="format-detection" content="telephone=no" />
+
+<title>Mailed in passport applications (adult renewals - PC7)</title>
+
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300italic,400,400italic,600,600italic,700,700italic">
+
+<link rel="stylesheet" href="/app/jquery-ui-1.11.4/jquery-ui.theme.min.css">
+
+<!-- Bootstrap -->
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="/app/bootstrap/3.3.5/css/bootstrap.min.css">
+
+<style>body {font-family: "Source Sans Pro", sans-serif}</style>
+<link rel="stylesheet" href="/app/bootstrap/3.3.5/css/bootstrap-theme.css">
+<!-- Simple Line Icons -->
+<link rel="stylesheet" href="/app/MegaNavbar/assets/plugins/simple-line-icons/simple-line-icons.css" >
+<!-- MegaNavbar-->
+
+<link rel="stylesheet" type="text/css" href="/app/MegaNavbar/assets/css/MegaNavbar.min.css">
+
+<link rel="stylesheet" type="text/css" href="/app/MegaNavbar/assets/css/skins/navbar-dfat.css">
+<link rel="stylesheet" type="text/css" href="/app/MegaNavbar/assets/css/skins/navbar-dfat-override.css">
+<link rel="stylesheet" type="text/css" href="/app/MegaNavbar/assets/css/animation/animation.css">
+<link rel="stylesheet" href="/app/font-awesome/4.4.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="/app/css/azmind/style.css">
+<link rel="stylesheet" type="text/css" href="/app/css/app.css" media="screen" >
+<link rel="stylesheet" type="text/css" href="/files/all/app.css" media="screen" >
+<link rel="stylesheet" type="text/css" href="/files/all/bkok.css" media="screen" >
+
+
+<link rel="Shortcut Icon" href="/app/css/favicon.ico?v=1398288707" type="image/x-icon" >
+
+
+<script type="0ab9ccea1efeaf9b1d089ba8-text/javascript">
+function popVar(value){
+return "";
+}
+</script>
+
+<!-- Google Tag Manager -->
+<script type="0ab9ccea1efeaf9b1d089ba8-text/javascript">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-54WMRR2');</script>
+<!-- End Google Tag Manager -->
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src=https://www.googletagmanager.com/ns.html?id=GTM-54WMRR2
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+</head>
+<body>
+<!--noindex-->
+
+<div class="container">
+<div class="row no-gutter">
+<div class="col-md-12">
+<input type="hidden" id="currentsite" name="currentsite" value="bkok" />
+<div class="row-fluid  content-header" id="content-header">
+<a id="homelink" href="/bkok/home.html"><img src="/app/images/coat-of-arms-black-80.png"></a>
+<div class="col-xs-12 col-md-7 site-title">
+<div >Australian Embassy</div>
+<div>Thailand</div>
+<div> </div>
+</div>
+<div class="col-xs-12 col-md-5 header-details">
+<div class="row-fluid no-gutter no-row-margin content-header-details-top-row ">
+<div class="col-xs-12">
+<span class="pull-right">
+<ul>
+<li class="top-hd-border"><a id="skipcontent" href="#main">Skip to main content</a></li>
+<li class="top-hd-border">Text size <span><a id="font-minus" class="btn azm-social azm-size-17 azm-r-square azm-language"
+title="Reduce text size."
+href="javascript:void(0);"><i class="fa fa-minus"></i>
+</a>
+<a id="font-plus" class="btn azm-social azm-size-17 azm-r-square azm-language"
+title="Increase text size."
+href="javascript:void(0);"><i class="fa fa-plus"></i>
+</a>
+</span>
+</li>
+<li class="top-hd-border">
+
+
+<ul class="languagelink">
+
+<li >
+
+
+
+</li>
+
+</ul>
+
+
+</li>
+</ul>
+</span>
+</div>
+</div>
+<div class="row-fluid no-gutter no-row-margin">
+<div class="col-xs-12 col-md-7 col-md-offset-5">
+<span class="pull-right">
+<form name="sbx" method="get" action="#" data-fbsearchurlprefix="//dfat-search.funnelback.squiz.cloud/s/search.html?collection=dfat~sp-embassies" data-fbscope="&scope=thailand.embassy.gov.au" >
+<div class="input-group">
+<input type="text" class="form-control input-sm" id="searchstring" placeholder="Search"/>
+<span class="input-group-addon"><a id="searchbtn" href="javascript:void(0);"><i class="fa fa-search"></i></a></span>
+</div>
+</form>
+</span>
+</div>
+</div>
+<div class="row-fluid no-gutter">
+<div class="col-xs-12">
+<div class="panel panel-default ecd">
+<div class="panel-body ">
+<span class="pull-right">
+<div></div>
+</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+</div>
+</div>
+</div>
+<nav class="navbar navbar-dfat no-border-radius SlideTopToBottom" data-duration="fast" role="navigation">
+<div class="container">
+<!-- for full width layout or use class="container" for boxed layout -->
+<div class="navbar-header ">
+<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#MegaNavbar">
+<span class="sr-only">Toggle navigation</span>
+<span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span>
+</button>
+</div>
+<div class="navbar-collapse collapse out" id="MegaNavbar" aria-expanded="true">
+<ul class="nav navbar-nav navbar-left">
+<!-- Left side navigation-->
+
+
+
+
+<li class="divider"></li>
+<li class="dropdown-short">
+<a data-toggle="dropdown" href="javascript:;" class="dropdown-toggle" aria-expanded="true">
+<span class="menu-table">
+<span class="menu-row">
+<span id="GlobalNav_AboutUs">
+About us
+</span>
+<span class="caret">
+&nbsp;
+</span>
+</span>
+</span>
+</a>
+<ul class="dropdown-menu">
+
+<li>
+
+<a href="/bkok/aboutus.html">
+About us
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/relations.html">
+Australia-Thailand relationship 
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Development_cooperat.html">
+Development Cooperation
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Direct_Aid_Program.html">
+Direct Aid Program
+</a>
+
+</li>
+
+</ul>
+</li>
+
+
+
+<li class="divider"></li>
+<li class="dropdown-short">
+<a data-toggle="dropdown" href="javascript:;" class="dropdown-toggle" aria-expanded="true">
+<span class="menu-table">
+<span class="menu-row">
+<span id="GlobalNav_Australians">
+Services for Australians
+</span>
+<span class="caret">
+&nbsp;
+</span>
+</span>
+</span>
+</a>
+<ul class="dropdown-menu">
+
+<li>
+
+<a href="/bkok/Consular_Services.html">
+Consular Services
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Australian_Passports_Page.html">
+Australian Passports
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Notarial_Services.html">
+Notarial Services
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Getting_Married_in_Thailand.html">
+Getting Married in Thailand
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Other_Services_for_Australians.html">
+Information for Australians in Thailand
+</a>
+
+</li>
+
+</ul>
+</li>
+
+
+
+<li class="divider"></li>
+<li class="dropdown-short">
+<a data-toggle="dropdown" href="javascript:;" class="dropdown-toggle" aria-expanded="true">
+<span class="menu-table">
+<span class="menu-row">
+<span id="GlobalNav_Connecting">
+Connecting with Australia
+</span>
+<span class="caret">
+&nbsp;
+</span>
+</span>
+</span>
+</a>
+<ul class="dropdown-menu">
+
+<li>
+
+<a href="/bkok/Australian_alumni_in_Thailand.html">
+Australian alumni in Thailand
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Visas_and_Migration.html">
+Visas and Immigration
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Defence.html">
+Defence
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/visiting_australia.html">
+Travelling to Australia
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/trade.html">
+Doing business with Australia
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Education.html">
+Australia-Thailand Education Cooperation
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Endeavour_Alumni_Stories.html">
+Endeavour Alumni Stories
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Thailand_Study_Guide.html">
+Thailand Study Guide
+</a>
+
+</li>
+
+</ul>
+</li>
+
+
+
+<li class="divider"></li>
+<li class="dropdown-short">
+<a data-toggle="dropdown" href="javascript:;" class="dropdown-toggle" aria-expanded="true">
+<span class="menu-table">
+<span class="menu-row">
+<span id="GlobalNav_Showcasing">
+Showcasing Australia
+</span>
+<span class="caret">
+&nbsp;
+</span>
+</span>
+</span>
+</a>
+<ul class="dropdown-menu">
+
+<li>
+
+<a href="/bkok/australia.html">
+About Australia
+</a>
+
+</li>
+
+</ul>
+</li>
+
+
+
+<li class="divider"></li>
+<li class="dropdown-short">
+<a data-toggle="dropdown" href="javascript:;" class="dropdown-toggle" aria-expanded="true">
+<span class="menu-table">
+<span class="menu-row">
+<span id="GlobalNav_NewsMedia">
+News and media
+</span>
+<span class="caret">
+&nbsp;
+</span>
+</span>
+</span>
+</a>
+<ul class="dropdown-menu">
+
+<li>
+
+<a href="/bkok/news.html">
+News
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/media.html">
+Media
+</a>
+
+</li>
+
+</ul>
+</li>
+
+
+
+<li class="divider"></li>
+<li class="dropdown-short">
+<a data-toggle="dropdown" href="javascript:;" class="dropdown-toggle" aria-expanded="true">
+<span class="menu-table">
+<span class="menu-row">
+<span id="GlobalNav_Bespoke">
+Job Opportunities
+</span>
+<span class="caret">
+&nbsp;
+</span>
+</span>
+</span>
+</a>
+<ul class="dropdown-menu">
+
+<li>
+
+<a href="/bkok/JobOpportunity.html">
+Job Opportunity
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Internship_Program.html">
+Internship Program
+</a>
+
+</li>
+
+</ul>
+</li>
+
+
+
+<li class="divider"></li>
+<li class="dropdown-short">
+<a data-toggle="dropdown" href="javascript:;" class="dropdown-toggle" aria-expanded="true">
+<span class="menu-table">
+<span class="menu-row">
+<span id="GlobalNav_Contact">
+Contact us
+</span>
+<span class="caret">
+&nbsp;
+</span>
+</span>
+</span>
+</a>
+<ul class="dropdown-menu">
+
+<li>
+
+<a href="/bkok/Event_Terms_and_Conditions.html">
+Event Terms and Conditions (Eng)
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Event_Terms_and_Conditions_Th.html">
+Event Terms and Conditions (Thai)
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/contact-us.html">
+Contact us
+</a>
+
+</li>
+
+
+
+</ul> <!-- end ul final menu in loop if not ending -->
+</li>
+
+
+
+</ul>
+
+</div>
+</div>
+</nav>
+<!-- end MegaNavbar-->
+
+
+<div id="page-banner">
+<div class="container">
+<div class="row">
+<div class="col-xs-12">
+
+
+
+<h1 class="h1Title">Mailed in passport applications (adult renewals - PC7)</h1>
+
+
+
+</div>
+</div>
+</div>
+</div> 
+
+<div class="container mainbody">
+<div class="row">
+<div class="col-md-9" id="main">
+ 
+<!--endnoindex-->
+
+<h2>&nbsp;</h2>
+
+<h4><img alt="" src="/files/bkok/graphic mailed in website.jpg" style="height:225px; width:400px" /></h4>
+
+<h3><strong>Eligibility</strong></h3>
+
+<p>For an Adult passport renewal, you must be 18 years and over and you will need a passport that:</p>
+
+<ul>
+	<li>was issued when you were aged 16 or older</li>
+	<li>was issued on or after 1 January 2006</li>
+	<li>had, when it was issued, at least two years&rsquo; validity</li>
+	<li>has your current name, date of birth, place of birth and gender</li>
+	<li>has not been reported lost, stolen, or cancelled, and</li>
+	<li>you are not requesting a <a href="https://www.passports.gov.au/help/replacement-passport">replacement passport</a></li>
+</ul>
+
+<p>If you can answer yes to all the above, complete your passport renewal application&nbsp;<a href="https://online.passports.gov.au/produce/">online</a>.</p>
+
+<p>If you don&rsquo;t meet these criteria, you&rsquo;ll need lodge your application in person by appointment only.</p>
+
+<p><a href="https://my.setmore.com/bookingpage/4d0e8f45-23ee-4b04-a10d-ab0149192866" id="Setmore_button_iframe" style="color: rgb(51, 122, 183); text-transform: none; text-indent: 0px; letter-spacing: normal; font-family: &quot;Source Sans Pro&quot;, sans-serif; font-size: 14px; font-style: normal; font-weight: 400; text-decoration: none; word-spacing: 0px; white-space: normal; box-sizing: border-box; orphans: 2; widows: 2; background-color: rgb(255, 255, 255); -webkit-text-stroke-width: 0px; font-variant-ligatures: normal; font-variant-caps: normal;"><img alt="Book an appointment with Australian Embassy Bangkok using SetMore" src="https://my.setmore.com/webapp/images/bookappt/SetMore-book-button.png" style="border-image:none; border:0px currentColor; box-sizing:border-box; vertical-align:middle" /></a></p>
+
+<h3><strong>For applications lodged by mail in Thailand</strong></h3>
+
+<ul>
+	<li>For mailed in passport applications, a drop off and collection service at the Embassy is NOT available</li>
+	<li>Please include a self-addressed envelope (either A5 or A4) for return of your completed document</li>
+	<li>DO NOT send any original documents, including your existing passport</li>
+	<li>Incomplete applications will be delayed. Common issues include:
+	<ul>
+		<li>Photos that don&rsquo;t meet the guidelines, are digitally altered, or have inks marks on them</li>
+		<li>Signatures must be inside the declaration &lsquo;white&rsquo; box, and application forms dated using the correct format (DD/MM/YYYY)</li>
+		<li>Credit cards that are not enabled for international transactions</li>
+	</ul>
+	</li>
+	<li>If your passport is damaged, please contact us to discuss prior to mailing in your application</li>
+	<li>If you are requesting a <a href="https://www.passports.gov.au/help/replacement-passport">replacement passport</a> you will need to lodge in person. To book an appointment, go to our <a href="https://thailand.embassy.gov.au/bkok/Australian_Passports_Page.html">main passports page</a>.</li>
+</ul>
+
+<h3><strong>Guide for Adult renewal application&nbsp;by mail</strong></h3>
+
+<table align="center" border="1" cellpadding="0" cellspacing="0" style="width:100%">
+	<tbody>
+		<tr>
+			<td style="width:25.5%">
+			<h4>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp; <img alt="" src="/files/bkok/Passport graphic1.jpg" style="height:96px; width:96px" /></h4>
+			</td>
+			<td style="width:74.5%">
+			<h4>&nbsp; 1. Complete your renewal application form <a href="https://online.passports.gov.au/produce/">online</a><br />
+			&nbsp;</h4>
+
+			<ul>
+				<li>The application must be lodged within six months of completion</li>
+			</ul>
+			</td>
+		</tr>
+		<tr>
+			<td style="width:25.5%">
+			<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; <img alt="" src="/files/bkok/Passport graphic2.jpg" /></p>
+			</td>
+			<td style="width:74.5%">
+			<h4>&nbsp; 2. Print and sign your application form<br />
+			&nbsp;</h4>
+
+			<ul>
+				<li><strong>Print</strong> on <strong>plain white A4 paper</strong>, using <strong>black ink</strong> only. Make sure the top or bottom of the page is not cut off.</li>
+				<li>US standard letter paper or US legal paper sizes are also acceptable, but only if they&rsquo;re scaled properly.</li>
+				<li><strong>Sign</strong> the form using <strong>black pen</strong>, <strong>within the signature box. </strong>Make sure there are no alterations or whiteout on the signature or the date.</li>
+			</ul>
+
+			<p>&nbsp;</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="height:119px; width:25.5%">
+			<h4>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp; <img alt="" src="/files/bkok/Passport graphic3.jpg" /></h4>
+			</td>
+			<td style="height:119px; width:74.5%">
+			<h4>&nbsp; 3. Photos</h4>
+
+			<p>&nbsp;</p>
+
+			<ul>
+				<li>Two recent identical colour photos, less than 6 months old with your full name written on the back of one photo. Refer to <a href="https://www.passports.gov.au/sites/default/files/2024-12/CameraOperatorGuide_A4-2025_1.pdf">photo guidelines</a> for more information</li>
+				<li>Do NOT attach the photos to the form as this may damage them</li>
+				<li>Ensure ink from the endorsed photo does not transfer to the unendorsed photo</li>
+			</ul>
+
+			<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;<img alt="" src="/files/bkok/ppt photo measurement.jpg" /></p>
+
+			<p>&nbsp;</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="width:25.5%">
+			<h4>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img alt="" src="/files/bkok/Passport graphic4.jpg" /></h4>
+			</td>
+			<td style="width:74.5%">
+			<h4>&nbsp; 4. Payment<br />
+			&nbsp;</h4>
+
+			<ul>
+				<li>Complete the <a href="https://thailand.embassy.gov.au/files/bkok/Credit card authorisation form (Bangkok-mar25).pdf">payment authorisation form (PDF)</a>, include this with your application form</li>
+			</ul>
+
+			<ul>
+				<li>You can view more information on <a href="https://thailand.embassy.gov.au/bkok/Notarial_Service_and_Passport_Fees.html#Passport%20Fees">passport fees</a></li>
+			</ul>
+
+			<p>&nbsp;</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="width:25.5%">
+			<h4>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;<img alt="" src="/files/bkok/Passport graphic5.jpg" /></h4>
+			</td>
+			<td style="width:74.5%">
+			<h4>&nbsp; 5. Check your adult renewal checklist<br />
+			&nbsp;</h4>
+
+			<ul>
+				<li>Before posting your application, review your <a href="https://thailand.embassy.gov.au/bkok/Passports_Checklists.html#Adult%20Passport%20Renewal%20(Single%20page%20streamlined%20renewal%20form)">adult renewal checklist</a></li>
+			</ul>
+
+			<p>&nbsp;</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="width:25.5%">
+			<h4>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img alt="" src="/files/bkok/Passport graphic6.jpg" /></h4>
+			</td>
+			<td style="width:74.5%">
+			<h4>&nbsp; 6. Post your application</h4>
+
+			<ul>
+				<li>Post your application to the Embassy in Bangkok or Consulate-General in Phuket via&nbsp;the local postal system (registered post is recommended).</li>
+				<li>You <strong>CANNOT</strong> submit your application in person without an appointment.</li>
+				<li>Please <strong>DO NOT</strong> use delivery service such as Grab, LINE Man, Kerry, to submit your mailed-in application.&nbsp; We accept mailed-in application that comes in the Post Office mail system only.</li>
+			</ul>
+
+			<p><br />
+			<strong>&nbsp; (Bangkok / Chiang Mai)</strong></p>
+
+			<p>&nbsp; Consular Services Section &ndash; Passport Services</p>
+
+			<p>&nbsp; Australian Embassy Bangkok</p>
+
+			<p>&nbsp; 181 Soi Arun McKinnon</p>
+
+			<p>&nbsp; Wireless Road,&nbsp;Lumphini, Pathumwan</p>
+
+			<p>&nbsp; Bangkok 10330</p>
+
+			<p>&nbsp;</p>
+
+			<p><strong>&nbsp; (Phuket)</strong></p>
+
+			<p>&nbsp; Consular Services Section &ndash; Passport Services</p>
+
+			<p>&nbsp; Australian Consulate-General Phuket</p>
+
+			<p>&nbsp; 6th&nbsp;Floor,&nbsp;CCM&nbsp;Complex</p>
+
+			<p>&nbsp; 77/77&nbsp;Chalermprakiat&nbsp;Rama&nbsp;9&nbsp;Road&nbsp;(Bypass&nbsp;Road)</p>
+
+			<p>&nbsp; Phuket&nbsp;&nbsp;83000&nbsp;&nbsp;</p>
+
+			<p>&nbsp;</p>
+
+			<p>&nbsp; <strong>Have you included:</strong></p>
+
+			<ul>
+				<li><strong>Your printed and signed application form</strong></li>
+				<li><strong>Passport photos</strong></li>
+				<li><strong>A self-addressed A5 or A4 envelope (postage stamps not required)</strong></li>
+				<li><strong>Completed payment authorisation form</strong></li>
+			</ul>
+
+			<p style="margin-left:17.85pt">&nbsp;</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="width:25.5%">
+			<h4>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img alt="" src="/files/bkok/Passport graphic7.jpg" /></h4>
+			</td>
+			<td style="width:74.5%">
+			<h4>&nbsp; 7. How long will it take?<br />
+			&nbsp;</h4>
+
+			<ul>
+				<li>Please allow <strong>a minimum of six weeks</strong> to receive a new passport once payment has been taken. <strong>PLEASE NOTE</strong> incomplete applications will cause delays.</li>
+				<li>We will post your new passport out to you via registered post (in-person collection is NOT available for mailed in applications)</li>
+			</ul>
+
+			<p>&nbsp;</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<div style="clear: both;">&nbsp;</div>
+
+<div style="clear: both;">
+<h1>Questions?</h1>
+
+<p>If you still have questions, please contact us directly to discuss before sending your application.</p>
+
+<p>&nbsp;</p>
+
+<p><strong>Bangkok </strong>(including Chiang Mai)</p>
+
+<p>Telephone: +66 (0) 2 344 6300, select Consular Services option</p>
+
+<p>Email: <a><span class="__cf_email__" data-cfemail="bcdfd3d2cfc9d0ddce92deddd2dbd7d3d7fcd8daddc892dbd3ca92ddc9">[email&#160;protected]</span></a></p>
+
+<p>&nbsp;</p>
+
+<p><strong>Phuket</strong></p>
+
+<p>Telephone: +66 (0) 76 317 700</p>
+
+<p>Email: <a><span class="__cf_email__" data-cfemail="593a36372a2c35382b7729312c323c2d193d3f382d773e362f77382c">[email&#160;protected]</span></a><strong> </strong></p>
+</div>
+
+
+<!--noindex-->
+ 
+</div>
+
+<div class="col-md-3">
+
+</div>
+ 
+</div>
+<div class="row no-row-margin no-gutter">
+
+</div>
+</div>
+
+<footer>
+<div id="content" class="container">
+<div class="row">
+<div class="col-md-3">
+<div class="row info">
+<div class="prominent col-xs-12">Australian Embassy<br/>Thailand<br/><span> </span></div>
+<div class="col-xs-12">181&nbsp;Soi&nbsp;ArunMcKinnon<br>Wireless&nbsp;Road,&nbsp;Lumphini<br>Pathumwan,&nbsp;Bangkok&nbsp;10330</div>
+
+
+<div class="col-xs-12"><a class="tel" href="tel:+6623446300">Telephone: +66 2 344 6300</a> </div>
+
+
+
+<div class="col-xs-12"><a class="tel" href="tel:+6623446593">Facsimile: +66 2 344 6593</a> </div>
+
+
+
+
+
+
+
+<div class="col-xs-12">Follow us:</div>
+</div>
+<div id="socialmedia-row" class="row no-row-margin no-gutter">
+
+<div class="col-xs-3 sm-icon" ><div><a class="btn azm-social azm-size-48 azm-facebook" href="#"><span class="fa fa-facebook"></span></a></div></div>
+
+<div class="col-xs-3 sm-icon" ><div><a class="btn azm-social azm-size-48" style="padding: 0;href="#"><img src="/files/all/X-Twitter-Icon2.jpg" /></a></div></div>
+
+</div>
+</div>
+<div class="col-md-6">
+
+
+<div class="panel-group no-gutter" id="accordion" role="tablist" aria-multiselectable="true">
+
+
+<div class="panel panel-default col-md-6">
+<div class="panel-heading" role="tab" id="heading0">
+<div class="panel-title">
+<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse0" aria-expanded="true" aria-controls="collapse0">
+<span>About us</span>
+</a>
+</div>
+</div>
+<div id="collapse0" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading0">
+<ul>
+
+<li>
+
+<a href="/bkok/aboutus.html">
+About us
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/relations.html">
+Australia-Thailand relationship 
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Development_cooperat.html">
+Development Cooperation
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Direct_Aid_Program.html">
+Direct Aid Program
+</a>
+
+</li>
+
+</ul>
+</div>
+</div>
+
+
+
+<div class="panel panel-default col-md-6">
+<div class="panel-heading" role="tab" id="heading4">
+<div class="panel-title">
+<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse4" aria-expanded="true" aria-controls="collapse4">
+<span>Services for Australians</span>
+</a>
+</div>
+</div>
+<div id="collapse4" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading4">
+<ul>
+
+<li>
+
+<a href="/bkok/Consular_Services.html">
+Consular Services
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Australian_Passports_Page.html">
+Australian Passports
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Notarial_Services.html">
+Notarial Services
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Getting_Married_in_Thailand.html">
+Getting Married in Thailand
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Other_Services_for_Australians.html">
+Information for Australians in Thailand
+</a>
+
+</li>
+
+</ul>
+</div>
+</div>
+
+
+
+<div class="panel panel-default col-md-6">
+<div class="panel-heading" role="tab" id="heading9">
+<div class="panel-title">
+<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse9" aria-expanded="true" aria-controls="collapse9">
+<span>Connecting with Australia</span>
+</a>
+</div>
+</div>
+<div id="collapse9" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading9">
+<ul>
+
+<li>
+
+<a href="/bkok/Australian_alumni_in_Thailand.html">
+Australian alumni in Thailand
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Visas_and_Migration.html">
+Visas and Immigration
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Defence.html">
+Defence
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/visiting_australia.html">
+Travelling to Australia
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/trade.html">
+Doing business with Australia
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Education.html">
+Australia-Thailand Education Cooperation
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Endeavour_Alumni_Stories.html">
+Endeavour Alumni Stories
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Thailand_Study_Guide.html">
+Thailand Study Guide
+</a>
+
+</li>
+
+</ul>
+</div>
+</div>
+
+
+
+<div class="panel panel-default col-md-6">
+<div class="panel-heading" role="tab" id="heading17">
+<div class="panel-title">
+<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse17" aria-expanded="true" aria-controls="collapse17">
+<span>Showcasing Australia</span>
+</a>
+</div>
+</div>
+<div id="collapse17" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading17">
+<ul>
+
+<li>
+
+<a href="/bkok/australia.html">
+About Australia
+</a>
+
+</li>
+
+</ul>
+</div>
+</div>
+
+
+
+<div class="panel panel-default col-md-6">
+<div class="panel-heading" role="tab" id="heading18">
+<div class="panel-title">
+<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse18" aria-expanded="true" aria-controls="collapse18">
+<span>News and media</span>
+</a>
+</div>
+</div>
+<div id="collapse18" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading18">
+<ul>
+
+<li>
+
+<a href="/bkok/news.html">
+News
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/media.html">
+Media
+</a>
+
+</li>
+
+</ul>
+</div>
+</div>
+
+
+
+<div class="panel panel-default col-md-6">
+<div class="panel-heading" role="tab" id="heading20">
+<div class="panel-title">
+<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse20" aria-expanded="true" aria-controls="collapse20">
+<span>Job Opportunities</span>
+</a>
+</div>
+</div>
+<div id="collapse20" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading20">
+<ul>
+
+<li>
+
+<a href="/bkok/JobOpportunity.html">
+Job Opportunity
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Internship_Program.html">
+Internship Program
+</a>
+
+</li>
+
+</ul>
+</div>
+</div>
+
+
+
+<div class="panel panel-default col-md-6">
+<div class="panel-heading" role="tab" id="heading22">
+<div class="panel-title">
+<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse22" aria-expanded="true" aria-controls="collapse22">
+<span>Contact us</span>
+</a>
+</div>
+</div>
+<div id="collapse22" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading22">
+<ul>
+
+<li>
+
+<a href="/bkok/Event_Terms_and_Conditions.html">
+Event Terms and Conditions (Eng)
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/Event_Terms_and_Conditions_Th.html">
+Event Terms and Conditions (Thai)
+</a>
+
+</li>
+
+
+
+<li>
+
+<a href="/bkok/contact-us.html">
+Contact us
+</a>
+
+</li>
+
+
+
+</ul> <!-- end ul final menu in loop if not ending on a last link-->
+</div>
+</div>
+
+</div>
+
+
+</div>
+<div class="col-md-3">
+
+
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+<div class="panel panel-default">
+<div class="panel-heading" role="tab" id="heading-footerlinks">
+<div class="panel-title">
+<a role="button" data-toggle="collapse"
+data-parent="#accordion" href="#collapse-footerlinks"
+aria-expanded="true" aria-controls="collapse-footerlinks">
+<span>External Websites</span>
+</a>
+</div>
+</div>
+<div id="collapse-footerlinks" class="panel-collapse collapse in"
+role="tabpanel" aria-labelledby="heading-footerlinks">
+<ul>
+
+<li>
+
+<a href="http://www.dfat.gov.au/">
+Department of Foreign Affairs and Trade
+</a>
+
+</li>
+
+<li>
+
+<a href="http://www.homeaffairs.gov.au/">
+Department of Home Affairs 
+</a>
+
+</li>
+
+<li>
+
+<a href="http://www.australia.com/en">
+Visit Australia
+</a>
+
+</li>
+
+<li>
+
+<a href="http://austrade.gov.au">
+Austrade
+</a>
+
+</li>
+
+<li>
+
+<a href="https://www.pm.gov.au/">
+Prime Minister of Australia
+</a>
+
+</li>
+
+<li>
+
+<a href="http://www.foreignminister.gov.au/">
+Minister for Foreign Affairs
+</a>
+
+</li>
+
+<li>
+
+<a href="http://www.trademinister.gov.au/">
+Minister for Trade and Tourism
+</a>
+
+</li>
+
+<li>
+
+<a href="http://ministers.dfat.gov.au/minister/pat-conroy/home">
+Minister for Pacific Island Affairs
+</a>
+
+</li>
+
+<li>
+
+<a href="http://ministers.dfat.gov.au/minister/anne-aly/home">
+Minister for International Development
+</a>
+
+</li>
+
+<li>
+
+<a href="http://minister.homeaffairs.gov.au/">
+Minister for Home Affairs
+</a>
+
+</li>
+
+</ul>
+</div>
+</div>
+</div>
+
+
+</div>
+</div>
+<div class="row">
+<div id="footer-links" class="col-md-12 footer-links">
+<ul>
+<li><a href="https://www.dfat.gov.au/about-us/about-this-website/copyright">Copyright</a></li>
+<li><a href="https://www.dfat.gov.au/about-us/corporate/privacy/Pages/privacy">Privacy</a></li>
+<li><a href="https://www.dfat.gov.au/about-us/about-this-website/Pages/disclaimer">Disclaimer</a></li>
+<li><a href="https://www.dfat.gov.au/about-us/about-this-website/accessibility">Accessibility</a></li>
+<li><a href="https://www.dfat.gov.au/about-us/corporate/freedom-of-information">Freedom of information</a></li>
+</ul>
+</div>
+</div>
+</div>
+</footer>
+
+<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+<!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+<!--[if lt IE 9]>
+<script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+<![endif]-->
+
+<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/app/jquery/1.11.3/jquery.min.js" type="0ab9ccea1efeaf9b1d089ba8-text/javascript"></script>
+<script src="/app/jquery-ui-1.11.4/jquery-ui.js" type="0ab9ccea1efeaf9b1d089ba8-text/javascript"></script>
+
+<script src="/app/bootstrap/3.3.5/js/bootstrap.min.js" type="0ab9ccea1efeaf9b1d089ba8-text/javascript"></script>
+
+<script src="/app/bootstrap/plugins/validator/dfat-modified/validator.js?v=1.04.01" type="0ab9ccea1efeaf9b1d089ba8-text/javascript"></script>
+<script src="/app/twitter/widgets.js" type="0ab9ccea1efeaf9b1d089ba8-text/javascript"></script>
+
+<script type="0ab9ccea1efeaf9b1d089ba8-text/javascript">
+
+srcValSVar = "";
+srcValEVar = "bkok";
+</script>
+<script type="0ab9ccea1efeaf9b1d089ba8-text/javascript" src="/app/css/common.js?v=1.04.01"></script>
+
+<script src="/app/lib/app_external.js?v=1.04.01" type="0ab9ccea1efeaf9b1d089ba8-text/javascript"></script>
+
+<script src="/app/lib/contentread.js?v=1.04.01" type="0ab9ccea1efeaf9b1d089ba8-text/javascript"></script>
+
+
+<script type="0ab9ccea1efeaf9b1d089ba8-text/javascript">
+$( document ).ready(function() {
+var smData = [];
+smData.push({h:"https://www.facebook.com/australiainthailand", t:"Facebook"});smData.push({h:"https://x.com/ausambbkk", t:"X"});
+var holder =
+$('div.sm-icon').each(function(i,e){$(e).find('a').attr({href: smData[i].h, title: smData[i].t});});
+});
+</script>
+<!--endnoindex-->
+<script src="/cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js" data-cf-settings="0ab9ccea1efeaf9b1d089ba8-|49" defer></script></body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `'#main'` to `ENTRY_POINT_ELEMENTS` in `src/constants.ts`, grouped with the existing `'main'` and `'[role="main"]'` selectors
- The existing `'main'` entry only matches `<main>` elements — it does not match `<div id="main">`, which is a common convention for main content containers
- Without `'#main'`, pages using `id="main"` fall through to lower-priority selectors like `'#content'`, which on some pages matches a footer or navigation container

## Reproduction

The fixture is from [thailand.embassy.gov.au](https://thailand.embassy.gov.au/bkok/Mailed_in_passport_applications.html), which uses:
- `<div class="col-md-9" id="main">` for the actual passport application content
- `<footer><div id="content" class="container">` for site-wide navigation links

Before this fix, Defuddle selected `footer > div#content` via the `'#content'` entry point and extracted only navigation boilerplate. With `'#main'` added, Defuddle correctly identifies `div#main` as the content container.

## Test plan

- [x] New fixture `entry-point--id-main` confirms correct extraction of passport content
- [x] Full test suite passes (309 tests, 0 failures)
- [x] No changes to existing expected outputs