### PR TITLE
Preserve ChatGPT citation footnotes

### DIFF
--- a/src/extractors/chatgpt.ts
+++ b/src/extractors/chatgpt.ts
@@ -58,13 +58,13 @@ export class ChatGPTExtractor extends ConversationExtractor {
 			// Remove specific elements from the message content
 			const tempDiv = this.document.createElement('div');
 			tempDiv.appendChild(parseHTML(this.document, messageContent));
-			tempDiv.querySelectorAll('h4.sr-only, h5.sr-only, h6.sr-only, span[data-state="closed"]').forEach(el => el.remove());
+			tempDiv.querySelectorAll('h4.sr-only, h5.sr-only, h6.sr-only').forEach(el => el.remove());
 			messageContent = serializeHTML(tempDiv);
 
 			// Process inline references using regex to find the containers
 			// Look for spans containing citation links (a[target=_blank][rel=noopener]), replacing entire structure
 			// Also capture optional preceding ZeroWidthSpace
-			const citationPattern = /(&ZeroWidthSpace;)?(<span[^>]*?>\s*<a(?=[^>]*?href="([^"]+)")(?=[^>]*?target="_blank")(?=[^>]*?rel="noopener")[^>]*?>[\s\S]*?<\/a>\s*<\/span>)/gi;
+			const citationPattern = /(&ZeroWidthSpace;)?(<span[^>]*?>\s*(?:<span[^>]*?>\s*)*<a(?=[^>]*?href="([^"]+)")(?=[^>]*?target="_blank")(?=[^>]*?rel="noopener")[^>]*?>[\s\S]*?<\/a>\s*(?:<\/span>\s*)+)/gi;
 
 			messageContent = messageContent.replace(citationPattern, (match, zws, spanStructure, url) => {
 				// url is captured group 3
@@ -113,6 +113,11 @@ export class ChatGPTExtractor extends ConversationExtractor {
 				// Return just the footnote reference, replacing the ZWS (if captured) and the entire span structure
 				return `<sup id="fnref:${footnoteNumber}"><a href="#fn:${footnoteNumber}">${footnoteNumber}</a></sup>`;
 			});
+
+			const cleanupDiv = this.document.createElement('div');
+			cleanupDiv.appendChild(parseHTML(this.document, messageContent));
+			cleanupDiv.querySelectorAll('span[data-state="closed"]').forEach(el => el.remove());
+			messageContent = serializeHTML(cleanupDiv);
 
 			// Clean up any stray empty paragraph tags
 			messageContent = messageContent

--- a/tests/expected/extractor--chatgpt-citations.md
+++ b/tests/expected/extractor--chatgpt-citations.md
@@ -1,0 +1,132 @@
+```json
+{
+  "title": "ChatGPT citation fixture",
+  "author": "",
+  "site": "ChatGPT",
+  "published": ""
+}
+```
+
+**You said**
+
+How do I choose a good air purifier for my bedroom? Please explain the key things to look for and cite reliable sources inline.
+
+---
+
+**ChatGPT said**
+
+For a bedroom air purifier, the most important thing is not the brand name—it's whether the purifier can clean the volume of air in your room effectively and quietly.
+
+### The 5 most important things to look for
+
+#### 1\. CADR (Clean Air Delivery Rate) — the most important specification
+
+CADR measures how much filtered air the purifier delivers. A higher CADR means faster removal of particles such as dust, pollen, and smoke. The U.S. EPA recommends choosing a purifier with a CADR large enough for the room where it will be used. For example, a 200 sq ft (≈19 m²) room should have a minimum CADR around 130 cfm (≈220 m³/h). [^1]
+
+**Rule of thumb:** Buy slightly larger than you need. A bigger purifier can run on a lower, quieter fan speed while still cleaning the room effectively. Community discussions and AHAM guidance commonly suggest a CADR of at least two-thirds of the room area (assuming standard ceiling height). [^1]
+
+#### 2\. A true HEPA filter
+
+For most bedrooms, a HEPA filter is the best choice. A true HEPA filter can capture at least 99.97% of particles 0.3 microns in size, including dust, pollen, mold spores, and many airborne allergens. [^2]
+
+If your main concern is:
+
+- Allergies
+- Pet dander
+- Dust
+- Pollen
+
+then HEPA filtration should be at the top of your checklist. [^2]
+
+#### 3\. Activated carbon if odors matter
+
+HEPA filters are excellent for particles, but they do not remove most gases or odors. If you want help with:
+
+- Cooking smells
+- Pet odors
+- VOCs from paints, furniture, or cleaning products
+
+look for a purifier that includes an activated carbon filter in addition to HEPA filtration. The EPA notes that gas removal requires specialized media such as activated carbon. [^1]
+
+#### 4\. Noise level in sleep mode
+
+Many purifiers achieve their advertised CADR only at maximum fan speed, which can be too loud for sleeping. Check the noise rating (dB) and read reviews about overnight use. A purifier that is quiet at the speed you'll actually use is often preferable to a louder unit with a slightly higher CADR. [^3]
+
+For a bedroom, many people find:
+
+- Under 30 dB: very quiet
+- 30–40 dB: generally acceptable
+- Above 45 dB: may disturb light sleepers
+
+#### 5\. Filter replacement cost
+
+Every purifier requires ongoing maintenance. The EPA emphasizes that filters must be replaced regularly; a clogged filter performs poorly. Before buying, check:
+
+- Replacement filter price
+- Replacement frequency
+- Availability in your country
+
+A purifier with cheap upfront pricing can become expensive if replacement filters cost a lot. [^1]
+
+---
+
+### Features that are nice but not essential
+
+- Air quality sensors
+- Auto mode
+- Wi-Fi/app control
+- Scheduling
+- Smart-home integration
+
+These can improve convenience but usually have much less impact on air cleaning performance than CADR, HEPA filtration, and proper sizing. [^4]
+
+---
+
+### Features I'd be cautious about
+
+Some purifiers advertise:
+
+- Ionizers
+- Ozone generation
+- "Plasma" technologies
+
+These may not provide meaningful benefits over a well-designed HEPA purifier, and ozone can irritate the lungs. Many indoor-air experts recommend prioritizing mechanical filtration (HEPA + carbon) first. [^2]
+
+---
+
+### Bedroom buying checklist
+
+A good bedroom air purifier should ideally have:
+
+✅ True HEPA filter  
+✅ CADR appropriate for your room size (or larger)  
+✅ Activated carbon filter if odors/VOCs matter  
+✅ Quiet sleep mode  
+✅ Reasonable replacement-filter costs  
+✅ Auto mode (optional)
+
+### Example products worth considering
+
+| Attribute | Coway Airmega 100 ilmanpuhdistin  €169.00•POWER.fi + others | Philips PureProtect Quiet 2200 Series  €279.00•Clas Ohlson FI + others | IKEA STARKVIND Air purifier  €149.00•IKEA |
+| --- | --- | --- | --- |
+| Bedroom-focused | Yes | Yes | Yes |
+| HEPA-style particle filtration | Yes | Yes | Yes |
+| Quiet operation emphasis | Good | Strong | Moderate |
+| Smart features | Limited | More extensive | Available on some versions |
+| Budget level | Mid-range | Mid-to-premium | Budget-to-mid |
+
+If you tell me:
+
+1. your bedroom size (m²),
+2. whether you have allergies, pets, smoke exposure, or odor concerns,
+3. and your budget,
+
+I can narrow it down to the most suitable models for your specific room.
+
+[^1]: [epa.gov](https://www.epa.gov/indoor-air-quality-iaq/guide-air-cleaners-home?utm_source=chatgpt.com)
+
+[^2]: [epa.gov](https://www.epa.gov/indoor-air-quality-iaq/what-hepa-filter?utm_source=chatgpt.com)
+
+[^3]: [wired.com](https://www.wired.com/story/youre-probably-using-your-air-purifier-wrong?utm_source=chatgpt.com)
+
+[^4]: [techradar.com](https://www.techradar.com/home/air-quality/how-to-choose-an-air-purifier-for-hay-fever?utm_source=chatgpt.com)

--- a/tests/fixtures/extractor--chatgpt-citations.html
+++ b/tests/fixtures/extractor--chatgpt-citations.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<!-- {"url":"https://chatgpt.com/share/example-citations"} -->
+<html>
+<head>
+	<title>ChatGPT citation fixture</title>
+</head>
+<body>
+	<main>
+		<section data-testid="conversation-turn-1"><h4 class="sr-only">You said:</h4><div><div><div><div data-message-author-role="user"><div><div><div class="whitespace-pre-wrap">How do I choose a good air purifier for my bedroom? Please explain the key things to look for and cite reliable sources inline.</div></div></div></div></div><div><div><button data-testid="copy-turn-action-button" data-state="closed"><span></span></button></div></div></div></div><span class="sr-only"><br></span></section>
+		<section data-testid="conversation-turn-2"><h4 class="sr-only">ChatGPT said:</h4><div><div><div><div data-message-author-role="assistant" data-turn-start-message="true"><div><div class="markdown"><p>For a bedroom air purifier, the most important thing is not the brand name—it's whether the purifier can clean the volume of air in your room effectively and quietly.</p>
+<h3>The 5 most important things to look for</h3>
+<h4><span>1. <strong>CADR (Clean Air Delivery Rate) — the most important specification</strong></span></h4>
+<p>CADR measures how much filtered air the purifier delivers. A higher CADR means faster removal of particles such as dust, pollen, and smoke. The U.S. EPA recommends choosing a purifier with a CADR large enough for the room where it will be used. For example, a 200 sq ft (≈19 m²) room should have a minimum CADR around 130 cfm (≈220 m³/h). <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.epa.gov/indoor-air-quality-iaq/guide-air-cleaners-home?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>US EPA</span></span><span>+1</span></span></span></a></span></span></p>
+<p><strong>Rule of thumb:</strong> Buy slightly larger than you need. A bigger purifier can run on a lower, quieter fan speed while still cleaning the room effectively. Community discussions and AHAM guidance commonly suggest a CADR of at least two-thirds of the room area (assuming standard ceiling height). <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.epa.gov/indoor-air-quality-iaq/guide-air-cleaners-home?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>US EPA</span></span><span>+2</span></span><span><span><span><img></span><span>Reddit</span></span><span>+2</span></span></span></a></span></span></p>
+<h4><span>2. <strong>A true HEPA filter</strong></span></h4>
+<p>For most bedrooms, a HEPA filter is the best choice. A true HEPA filter can capture at least 99.97% of particles 0.3 microns in size, including dust, pollen, mold spores, and many airborne allergens. <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.epa.gov/indoor-air-quality-iaq/what-hepa-filter?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>US EPA</span></span></span></span></a></span></span></p>
+<p>If your main concern is:</p>
+<ul>
+<li>
+<p>Allergies</p>
+</li>
+<li>
+<p>Pet dander</p>
+</li>
+<li>
+<p>Dust</p>
+</li>
+<li>
+<p>Pollen</p>
+</li>
+</ul>
+<p>then HEPA filtration should be at the top of your checklist. <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.epa.gov/indoor-air-quality-iaq/what-hepa-filter?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>US EPA</span></span><span>+1</span></span></span></a></span></span></p>
+<h4><span>3. <strong>Activated carbon if odors matter</strong></span></h4>
+<p>HEPA filters are excellent for particles, but they do not remove most gases or odors. If you want help with:</p>
+<ul>
+<li>
+<p>Cooking smells</p>
+</li>
+<li>
+<p>Pet odors</p>
+</li>
+<li>
+<p>VOCs from paints, furniture, or cleaning products</p>
+</li>
+</ul>
+<p>look for a purifier that includes an activated carbon filter in addition to HEPA filtration. The EPA notes that gas removal requires specialized media such as activated carbon. <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.epa.gov/indoor-air-quality-iaq/guide-air-cleaners-home?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>US EPA</span></span></span></span></a></span></span></p>
+<h4><span>4. <strong>Noise level in sleep mode</strong></span></h4>
+<p>Many purifiers achieve their advertised CADR only at maximum fan speed, which can be too loud for sleeping. Check the noise rating (dB) and read reviews about overnight use. A purifier that is quiet at the speed you'll actually use is often preferable to a louder unit with a slightly higher CADR. <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.wired.com/story/youre-probably-using-your-air-purifier-wrong?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>WIRED</span></span><span>+1</span></span></span></a></span></span></p>
+<p>For a bedroom, many people find:</p>
+<ul>
+<li>
+<p>Under 30 dB: very quiet</p>
+</li>
+<li>
+<p>30–40 dB: generally acceptable</p>
+</li>
+<li>
+<p>Above 45 dB: may disturb light sleepers</p>
+</li>
+</ul>
+<h4><span>5. <strong>Filter replacement cost</strong></span></h4>
+<p>Every purifier requires ongoing maintenance. The EPA emphasizes that filters must be replaced regularly; a clogged filter performs poorly. Before buying, check:</p>
+<ul>
+<li>
+<p>Replacement filter price</p>
+</li>
+<li>
+<p>Replacement frequency</p>
+</li>
+<li>
+<p>Availability in your country</p>
+</li>
+</ul>
+<p>A purifier with cheap upfront pricing can become expensive if replacement filters cost a lot. <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.epa.gov/indoor-air-quality-iaq/guide-air-cleaners-home?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>US EPA</span></span><span>+1</span></span></span></a></span></span></p>
+<hr>
+<h3>Features that are nice but not essential</h3>
+<ul>
+<li>
+<p>Air quality sensors</p>
+</li>
+<li>
+<p>Auto mode</p>
+</li>
+<li>
+<p>Wi-Fi/app control</p>
+</li>
+<li>
+<p>Scheduling</p>
+</li>
+<li>
+<p>Smart-home integration</p>
+</li>
+</ul>
+<p>These can improve convenience but usually have much less impact on air cleaning performance than CADR, HEPA filtration, and proper sizing. <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.techradar.com/home/air-quality/how-to-choose-an-air-purifier-for-hay-fever?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>TechRadar</span></span><span>+1</span></span></span></a></span></span></p>
+<hr>
+<h3>Features I'd be cautious about</h3>
+<p>Some purifiers advertise:</p>
+<ul>
+<li>
+<p>Ionizers</p>
+</li>
+<li>
+<p>Ozone generation</p>
+</li>
+<li>
+<p>"Plasma" technologies</p>
+</li>
+</ul>
+<p>These may not provide meaningful benefits over a well-designed HEPA purifier, and ozone can irritate the lungs. Many indoor-air experts recommend prioritizing mechanical filtration (HEPA + carbon) first. <span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://www.epa.gov/indoor-air-quality-iaq/what-hepa-filter?utm_source=chatgpt.com" target="_blank" rel="noopener"><span><span><span><span><img></span><span>US EPA</span></span><span>+1</span></span></span></a></span></span></p>
+<hr>
+<h3>Bedroom buying checklist</h3>
+<p>A good bedroom air purifier should ideally have:</p>
+<p>✅ True HEPA filter<br>
+✅ CADR appropriate for your room size (or larger)<br>
+✅ Activated carbon filter if odors/VOCs matter<br>
+✅ Quiet sleep mode<br>
+✅ Reasonable replacement-filter costs<br>
+✅ Auto mode (optional)</p>
+<h3>Example products worth considering</h3>
+<div><div><table><thead><tr><th>Attribute</th><th><div><div><button><span></span><span><span><span></span></span></span></button><img></div><div><div>Coway Airmega 100 ilmanpuhdistin</div><div><span>€169.00</span><span>•</span><span>POWER.fi + others</span></div></div></div></th><th><div><div><button><span></span><span><span><span></span></span></span></button><img></div><div><div>Philips PureProtect Quiet 2200 Series</div><div><span>€279.00</span><span>•</span><span>Clas Ohlson FI + others</span></div></div></div></th><th><div><div><button><span></span><span><span><span></span></span></span></button><img></div><div><div>IKEA STARKVIND Air purifier</div><div><span>€149.00</span><span>•</span><span>IKEA</span></div></div></div></th></tr></thead><tbody><tr><td>Bedroom-focused</td><td>Yes</td><td>Yes</td><td>Yes</td></tr><tr><td>HEPA-style particle filtration</td><td>Yes</td><td>Yes</td><td>Yes</td></tr><tr><td>Quiet operation emphasis</td><td>Good</td><td>Strong</td><td>Moderate</td></tr><tr><td>Smart features</td><td>Limited</td><td>More extensive</td><td>Available on some versions</td></tr><tr><td>Budget level</td><td>Mid-range</td><td>Mid-to-premium</td><td>Budget-to-mid</td></tr></tbody></table><div><div><span data-state="closed"><button></button></span></div></div></div></div>
+<p>If you tell me:</p>
+<ol>
+<li>
+<p>your bedroom size (m²),</p>
+</li>
+<li>
+<p>whether you have allergies, pets, smoke exposure, or odor concerns,</p>
+</li>
+<li>
+<p>and your budget,</p>
+</li>
+</ol>
+<p>I can narrow it down to the most suitable models for your specific room.</p></div></div></div></div><div><div><button data-testid="copy-turn-action-button" data-state="closed"><span></span></button><button data-state="closed"><span></span></button><button><div><div><div><img></div></div><div><div><img></div></div><div><div><img></div></div></div><div>Sources</div></button></div></div></div></div></section>
+	</main>
+</body>
+</html>


### PR DESCRIPTION
Fix ChatGPT extraction so modern citation pills are preserved as inline footnotes.

ChatGPT wraps citation links in nested `span[data-state="closed"]` markup. The extractor previously removed those closed-state spans before citation extraction, which caused the source links to be dropped before they could be converted into footnotes.

This keeps the closed-state cleanup, but runs it after citation pills are converted.

Added a fixture captured from a current ChatGPT conversation to cover the citation markup.