### PR TITLE
CLI: add --frontmatter flag for YAML metadata output

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ npx defuddle parse https://example.com/article --user-agent "Mozilla/5.0 (Macint
 | `--markdown` | `-m` | Convert content to markdown format |
 | `--md` | | Alias for `--markdown` |
 | `--json` | `-j` | Output as JSON with metadata and content |
+| `--frontmatter` | `-f` | Prepend YAML frontmatter (title, author, source, etc.) to the output |
 | `--property <name>` | `-p` | Extract a specific property (e.g., title, description, domain) |
 | `--debug` | | Enable debug mode |
 | `--lang <code>` | `-l` | Preferred language (BCP 47, e.g. `en`, `fr`, `ja`) |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { writeFile, readFile } from 'fs/promises';
 import { resolve } from 'path';
 import { parseLinkedomHTML } from './utils/linkedom-compat';
 import { countWords } from './utils';
+import { buildFrontmatter } from './frontmatter';
 import { getInitialUA, fetchPage, extractRawMarkdown, cleanMarkdownContent, BOT_UA } from './fetch';
 
 export interface ParseOptions {
@@ -17,6 +18,7 @@ export interface ParseOptions {
 	property?: string;
 	lang?: string;
 	userAgent?: string;
+	frontmatter?: boolean;
 }
 
 interface ParseResult {
@@ -145,7 +147,7 @@ export async function parseSource(source: string | undefined, options: ParseOpti
 			...(result.variables ? { variables: result.variables } : {}),
 		}, null, 2);
 	} else {
-		output = result.content;
+		output = options.frontmatter ? buildFrontmatter(result, url) + result.content : result.content;
 	}
 
 	return { output };
@@ -167,6 +169,7 @@ export function createProgram(): Command {
 		.option('-m, --markdown', 'Convert content to markdown format')
 		.option('--md', 'Alias for --markdown')
 		.option('-j, --json', 'Output as JSON with metadata and content')
+		.option('-f, --frontmatter', 'Prepend YAML frontmatter (title, author, source, etc.) to the output')
 		.option('-p, --property <name>', 'Extract a specific property (e.g., title, description, domain)')
 		.option('--debug', 'Enable debug mode')
 		.option('-l, --lang <code>', 'Preferred language (BCP 47, e.g. en, fr, ja)')

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,0 +1,67 @@
+import { countWords } from './utils';
+import type { DefuddleResponse } from './types';
+
+// Count words, treating each CJK character as one word (mirrors countWords),
+// and truncate the text once maxWords is exceeded.
+function truncateWords(text: string, maxWords: number): string {
+	let words = 0;
+	let inWord = false;
+
+	for (let i = 0; i < text.length; i++) {
+		const code = text.charCodeAt(i);
+		const isCJK = (
+			(code >= 0x3040 && code <= 0x309f) ||
+			(code >= 0x30a0 && code <= 0x30ff) ||
+			(code >= 0x3400 && code <= 0x4dbf) ||
+			(code >= 0x4e00 && code <= 0x9fff) ||
+			(code >= 0xf900 && code <= 0xfaff) ||
+			(code >= 0xac00 && code <= 0xd7af)
+		);
+
+		if (isCJK) {
+			words++;
+			inWord = false;
+		} else if (code <= 32) {
+			inWord = false;
+		} else if (!inWord) {
+			words++;
+			inWord = true;
+		}
+
+		if (words > maxWords) {
+			return text.slice(0, i).trimEnd() + '…';
+		}
+	}
+	return text;
+}
+
+/**
+ * Build a YAML frontmatter block ("---\n…\n---\n\n") from extracted metadata.
+ * Shared by the CLI (`--frontmatter`) and the defuddle.md worker so both emit
+ * identical output. `source:` is only emitted when a sourceUrl is provided
+ * (CLI stdin/file input has no URL).
+ */
+export function buildFrontmatter(result: DefuddleResponse, sourceUrl?: string): string {
+	const lines: string[] = ['---'];
+
+	// Escape a string for use as a YAML double-quoted value
+	const esc = (s: string) => s.replace(/"/g, '\\"').replace(/\n/g, ' ');
+
+	if (result.title) lines.push(`title: "${esc(result.title)}"`);
+	if (result.author) lines.push(`author: "${esc(result.author)}"`);
+	if (result.site) lines.push(`site: "${esc(result.site)}"`);
+	if (result.published) lines.push(`published: ${result.published}`);
+	if (sourceUrl) lines.push(`source: "${sourceUrl}"`);
+	if (result.domain) lines.push(`domain: "${result.domain}"`);
+	if (result.language) lines.push(`language: "${result.language}"`);
+	if (result.description) {
+		const desc = countWords(result.description) > 300
+			? truncateWords(result.description, 300)
+			: result.description;
+		lines.push(`description: "${esc(desc)}"`);
+	}
+	if (result.wordCount) lines.push(`word_count: ${result.wordCount}`);
+
+	lines.push('---');
+	return lines.join('\n') + '\n\n';
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -69,6 +69,33 @@ describe('CLI parseSource', () => {
 		);
 	});
 
+	test('prepends YAML frontmatter when --frontmatter is set', async () => {
+		const body = await getExpectedContent(fixtureHtml);
+
+		const result = await parseSource(undefined, { frontmatter: true }, createMockStdin(fixtureHtml));
+
+		expect(result.output.startsWith('---\n')).toBe(true);
+		expect(result.output).toContain('title: "Article with Appendix"');
+		// frontmatter block closes with --- followed by a blank line, then the body
+		expect(result.output).toContain('---\n\n' + body);
+		// stdin input has no URL, so no source: line is emitted
+		expect(result.output).not.toContain('source:');
+	});
+
+	test('omits frontmatter by default', async () => {
+		const result = await parseSource(undefined, {}, createMockStdin(fixtureHtml));
+		expect(result.output.startsWith('---')).toBe(false);
+	});
+
+	test('registers the --frontmatter flag with a -f alias', () => {
+		const parseCommand = createProgram().commands.find((c) => c.name() === 'parse');
+		const option = parseCommand?.options.find((o) => o.long === '--frontmatter');
+
+		expect(option).toBeDefined();
+		expect(option?.short).toBe('-f');
+		expect(option?.attributeName()).toBe('frontmatter');
+	});
+
 	test('registers the --user-agent flag with a -u alias', () => {
 		const parseCommand = createProgram().commands.find((c) => c.name() === 'parse');
 		const option = parseCommand?.options.find((o) => o.long === '--user-agent');

--- a/website/src/convert.ts
+++ b/website/src/convert.ts
@@ -2,6 +2,7 @@ import { parseLinkedomHTML } from '../../src/utils/linkedom-compat';
 import { Defuddle } from '../../src/defuddle';
 import { toMarkdown } from '../../src/markdown';
 import { countWords } from '../../src/utils';
+import { buildFrontmatter } from '../../src/frontmatter';
 import { getInitialUA, fetchPage, extractRawMarkdown, cleanMarkdownContent, BOT_UA, DEFAULT_UA, FETCH_TIMEOUT } from '../../src/fetch';
 import type { DefuddleOptions, DefuddleResponse } from '../../src/types';
 
@@ -198,74 +199,6 @@ export async function convertToMarkdown(targetUrl: string, language?: string): P
 	return result;
 }
 
-function truncateWords(text: string, maxWords: number): string {
-	let words = 0;
-	let inWord = false;
-
-	for (let i = 0; i < text.length; i++) {
-		const code = text.charCodeAt(i);
-		const isCJK = (
-			(code >= 0x3040 && code <= 0x309f) ||
-			(code >= 0x30a0 && code <= 0x30ff) ||
-			(code >= 0x3400 && code <= 0x4dbf) ||
-			(code >= 0x4e00 && code <= 0x9fff) ||
-			(code >= 0xf900 && code <= 0xfaff) ||
-			(code >= 0xac00 && code <= 0xd7af)
-		);
-
-		if (isCJK) {
-			words++;
-			inWord = false;
-		} else if (code <= 32) {
-			inWord = false;
-		} else if (!inWord) {
-			words++;
-			inWord = true;
-		}
-
-		if (words > maxWords) {
-			return text.slice(0, i).trimEnd() + '…';
-		}
-	}
-	return text;
-}
-
 export function formatResponse(result: DefuddleResponse, sourceUrl: string): string {
-	const frontmatter: string[] = ['---'];
-
-	// Escape a string for use as a YAML double-quoted value
-	const esc = (s: string) => s.replace(/"/g, '\\"').replace(/\n/g, ' ');
-
-	if (result.title) {
-		frontmatter.push(`title: "${esc(result.title)}"`);
-	}
-	if (result.author) {
-		frontmatter.push(`author: "${esc(result.author)}"`);
-	}
-	if (result.site) {
-		frontmatter.push(`site: "${esc(result.site)}"`);
-	}
-	if (result.published) {
-		frontmatter.push(`published: ${result.published}`);
-	}
-	frontmatter.push(`source: "${sourceUrl}"`);
-	if (result.domain) {
-		frontmatter.push(`domain: "${result.domain}"`);
-	}
-	if (result.language) {
-		frontmatter.push(`language: "${result.language}"`);
-	}
-	if (result.description) {
-		const desc = countWords(result.description) > 300
-			? truncateWords(result.description, 300)
-			: result.description;
-		frontmatter.push(`description: "${esc(desc)}"`);
-	}
-	if (result.wordCount) {
-		frontmatter.push(`word_count: ${result.wordCount}`);
-	}
-
-	frontmatter.push('---');
-
-	return frontmatter.join('\n') + '\n\n' + result.content;
+	return buildFrontmatter(result, sourceUrl) + result.content;
 }


### PR DESCRIPTION
Closes #312

**What** — Adds `-f, --frontmatter` to `defuddle parse`. With `--markdown`, the CLI prepends the same YAML frontmatter the defuddle.md worker emits (`title`, `author`, `site`, `source`, `domain`, `language`, `description`, `word_count`) — byte-identical to `curl https://defuddle.md/<url>`.

**Why** — The CLI previously output only the body; metadata was available only via `--json`. Useful for archiving articles into Markdown notes.

**How** — The frontmatter logic lived only in the worker (`website/src/convert.ts`). Rather than copy it into the CLI, I hoisted it into a shared `src/frontmatter.ts` that both import; `formatResponse` now delegates to `buildFrontmatter`. `source:` is only emitted when a URL is known (stdin/file input has none).

**Tests** — New `tests/cli.test.ts` cases (prepend with `-f`, omitted by default, flag registered with `-f` alias). Full suite 311/311. Verified byte-identical to the API on a real article.