### PR TITLE
fix: remove subhead class from partial selector

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -889,7 +889,6 @@ export const PARTIAL_SELECTORS = [
 	'storysmall',
 	'storypublishdate', // Medium
 	'subject-label',
-	'subhead',
 	'submenu',
 //	'subscribe',
 	'-subscribe-',

--- a/tests/expected/selectors--article-subheading.md
+++ b/tests/expected/selectors--article-subheading.md
@@ -1,0 +1,14 @@
+```json
+{
+  "title": "Campaign Update",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+The article opens with a summary of a local campaign and explains why the next stage matters to readers. It provides enough surrounding context that the subsection heading is clearly part of the main story rather than navigation, metadata, or promotional clutter.
+
+## Local Team Starts Catch-Up Campaign
+
+The second section describes the plan in plain language. Organizers will visit neighborhoods, answer questions, and publish a schedule after the next meeting. The heading above should be preserved because it introduces this article section.

--- a/tests/fixtures/selectors--article-subheading.html
+++ b/tests/fixtures/selectors--article-subheading.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Campaign Update</title>
+</head>
+<body>
+	<article>
+		<h1>Campaign Update</h1>
+		<p>The article opens with a summary of a local campaign and explains why the next stage matters to readers. It provides enough surrounding context that the subsection heading is clearly part of the main story rather than navigation, metadata, or promotional clutter.</p>
+		<h2 class="article__subheading article__item ">Local Team Starts Catch-Up Campaign</h2>
+		<p>The second section describes the plan in plain language. Organizers will visit neighborhoods, answer questions, and publish a schedule after the next meeting. The heading above should be preserved because it introduces this article section.</p>
+	</article>
+</body>
+</html>


### PR DESCRIPTION
The partial selector `subhead` removes actual headings for example with this class:

```html
<h2 class="article__subheading article__item ">Subheader</h2>
```

This comes from this site [here](https://www.zeit.de/news/2026-06/13/spd-will-mit-schwesig-an-der-spitze-staerkste-kraft-bleiben).

I didn't find a good reason to keep it, let me know if there is.