### PR TITLE
fix: prefer async extraction in Node for X articles

### DIFF
--- a/src/extractors/x-oembed.ts
+++ b/src/extractors/x-oembed.ts
@@ -129,6 +129,12 @@ export class XOembedExtractor extends BaseExtractor {
 		return /\/(status|article)\/\d+/.test(this.url);
 	}
 
+	prefersAsync(): boolean {
+		// Prefer async when not running in a browser window context.
+		const isBrowser = typeof window !== 'undefined' && this.document.defaultView == window;
+		return !isBrowser;
+	}
+
 	async extractAsync(): Promise<ExtractorResult> {
 		// Try FxTwitter first — it has full tweet text and media
 		const fxResult = await this.tryExtractFxTwitter();


### PR DESCRIPTION
**Description**
X (Twitter) articles now show only a preview, and Defuddle currently fetches the preview text when used via the Node.js API or CLI, as described in #314.

**Changes**
This fix adds `prefersAsync()` to `XOembedExtractor` to bypass the synchronous extraction path when not running in a browser. `prefersAsync()` returns true when the request is made outside a browser.

Fixes #314