### PR TITLE
Batch fix issues

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -990,6 +990,7 @@ export const FOOTNOTE_INLINE_REFERENCES = [
 	'sup[data-fn] > a[href^="#"]', // WordPress block editor footnotes
 	'sup[id^="ftnt_ref"] a[href^="#ftnt"]', // Google Docs/Sites
 	'span.easy-footnote > a[href^="#easy-footnote-bottom-"]', // Easy Footnotes WP plugin
+	'a.footnote[href^="#"]', // GNU Texinfo / makeinfo inline markers
 	'a[data-type="noteref"]', // O'Reilly / HTMLBook
 ].join(',');
 
@@ -1014,6 +1015,7 @@ export const FOOTNOTE_LIST_SELECTORS = [
 	'div.footnote-definition', // pulldown-cmark / mdBook / zola (unwrapped)
 	'ol.wp-block-footnotes', // WordPress block editor footnotes
 	'ol.easy-footnotes-wrapper', // Easy Footnotes WP plugin
+	'div.footnotes-segment', // GNU Texinfo / makeinfo
 	'#footnotes' // standardizeFootnotes output container
 ].join(',');
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -990,6 +990,7 @@ export const FOOTNOTE_INLINE_REFERENCES = [
 	'sup[data-fn] > a[href^="#"]', // WordPress block editor footnotes
 	'sup[id^="ftnt_ref"] a[href^="#ftnt"]', // Google Docs/Sites
 	'span.easy-footnote > a[href^="#easy-footnote-bottom-"]', // Easy Footnotes WP plugin
+	'a[data-type="noteref"]', // O'Reilly / HTMLBook
 ].join(',');
 
 export const FOOTNOTE_LIST_SELECTORS = [

--- a/src/defuddle.ts
+++ b/src/defuddle.ts
@@ -288,32 +288,36 @@ export class Defuddle {
 			}
 		}
 
-		// Also deduplicate adjacent images outside figures (same alt, different src)
+		// Also deduplicate images outside figures that are the same image rendered
+		// twice by lazy-load hydration: a placeholder/low-res copy *alongside* the
+		// real one. Only collapse when the two <img> are genuinely adjacent in the
+		// DOM — distinct article images separated by text are real content even when
+		// they share generic or boilerplate alt text (e.g. alt="image", or a CMS that
+		// reuses the article title as alt), so they must be kept (#286).
 		const imgs = Array.from(body.querySelectorAll('img'));
-		for (let i = 0; i < imgs.length; i++) {
+		for (let i = 0; i < imgs.length - 1; i++) {
 			const img = imgs[i];
+			if (!img.parentElement) continue; // already removed as a loser
 			if (img.closest('noscript') || img.closest('figure')) continue;
-			if (!img.parentElement) continue;
 
 			const alt = (img.getAttribute('alt') || '').trim();
 			if (!alt) continue;
 			const src = img.getAttribute('src') || '';
 			if (!src || src.startsWith('data:')) continue;
 
-			for (let j = i + 1; j < imgs.length; j++) {
-				const other = imgs[j];
-				if (other.closest('noscript') || other.closest('figure')) continue;
-				if (!other.parentElement) continue;
+			const other = imgs[i + 1];
+			if (!other.parentElement) continue;
+			if (other.closest('noscript') || other.closest('figure')) continue;
 
-				const otherAlt = (other.getAttribute('alt') || '').trim();
-				if (otherAlt !== alt) break;
-				const otherSrc = other.getAttribute('src') || '';
-				if (!otherSrc || otherSrc.startsWith('data:')) continue;
-				if (otherSrc === src) break; // legitimate repeat
+			if ((other.getAttribute('alt') || '').trim() !== alt) continue;
+			const otherSrc = other.getAttribute('src') || '';
+			if (!otherSrc || otherSrc.startsWith('data:')) continue;
+			if (otherSrc === src) continue; // legitimate repeat (same image twice)
 
-				this._keepBestImage([img, other]);
-				if (!img.parentElement) break; // img was the loser
-			}
+			// Require true adjacency: only whitespace/wrapper markup between them.
+			if (!this._noVisibleContentBetween(img, other)) continue;
+
+			this._keepBestImage([img, other]);
 		}
 
 		// Remove lightbox duplicate images: a standalone <img> whose src matches
@@ -346,6 +350,31 @@ export class Defuddle {
 			(winner === best ? group[i] : best).remove();
 			best = winner;
 		}
+	}
+
+	/**
+	 * True when nothing but whitespace and wrapper markup sits between `a` and `b`
+	 * in document order (`a` must precede `b`). Used to confirm two <img> are a
+	 * genuine lazy-load duplicate pair rather than distinct images separated by text.
+	 */
+	private _noVisibleContentBetween(a: Node, b: Node): boolean {
+		const next = (node: Node | null): Node | null => {
+			if (!node) return null;
+			if (node.firstChild) return node.firstChild;
+			let n: Node | null = node;
+			while (n) {
+				if (n.nextSibling) return n.nextSibling;
+				n = n.parentNode;
+			}
+			return null;
+		};
+		const TEXT_NODE = 3;
+		for (let node = next(a); node && node !== b; node = next(node)) {
+			if (node.nodeType === TEXT_NODE) {
+				if ((node.textContent || '').trim()) return false;
+			}
+		}
+		return true;
 	}
 
 	/** Strip protocol and query string for loose URL comparison. */

--- a/src/elements/footnotes.ts
+++ b/src/elements/footnotes.ts
@@ -92,6 +92,9 @@ const INLINE_REF_EXTRACTORS: Array<{ selector: string; extract: (el: any) => str
 	{ selector: 'span.footnote-link', extract: (el) => el.getAttribute('data-footnote-id') || '' },
 	{ selector: 'a.citation', extract: (el) => el.textContent?.trim() || '' },
 	{ selector: 'a[id^="fnref"]', extract: (el) => el.id.replace('fnref', '').toLowerCase() },
+	// O'Reilly/HTMLBook: <a data-type="noteref" href="chNN.html#chMMfnK"> — the id is the
+	// href fragment, which may include a same-document filename prefix.
+	{ selector: 'a[data-type="noteref"]', extract: (el) => getHrefFragment(el) },
 ];
 
 class FootnoteHandler {
@@ -284,6 +287,7 @@ class FootnoteHandler {
 		});
 
 		const fallbacks = [
+			this.tryDataTypeFootnotes,
 			this.tryGenericIdDetection,
 			this.tryWordExport,
 			this.tryGoogleDocs,
@@ -297,6 +301,30 @@ class FootnoteHandler {
 		}
 
 		return state.footnotes;
+	}
+
+	// O'Reilly / HTMLBook: footnote definitions are <p data-type="footnote" id="chNNfnK">,
+	// each opening with a <sup><a href="#…-marker">K</a></sup> backlink. The body text
+	// (including the inline <a data-type="noteref"> markers) is otherwise indistinguishable
+	// from definitions to tryGenericIdDetection, which would mis-collect surrounding
+	// paragraphs as footnote content (#296), so handle this explicit markup first.
+	private tryDataTypeFootnotes(element: any, state: CollectState): void {
+		const defs = element.querySelectorAll('p[data-type="footnote"][id]');
+		defs.forEach((def: any) => {
+			const id = (def.id || '').toLowerCase();
+			if (!id) return;
+			const contentDiv = element.ownerDocument.createElement('div');
+			const clone = def.cloneNode(true);
+			// Strip the leading backlink marker (<sup><a href="#…-marker">K</a></sup>).
+			const marker = clone.firstElementChild;
+			if (marker && marker.tagName.toLowerCase() === 'sup' && marker.querySelector('a[href*="#"]')) {
+				marker.remove();
+				this.trimLeadingWhitespace(clone);
+			}
+			contentDiv.appendChild(clone);
+			this.addFootnote(state, id, contentDiv);
+			this.pendingRemovals.push(def);
+		});
 	}
 
 	// Generic fallback: detect footnotes by numeric anchor text referencing an in-container id.

--- a/src/elements/footnotes.ts
+++ b/src/elements/footnotes.ts
@@ -269,6 +269,30 @@ class FootnoteHandler {
 				return;
 			}
 
+			// GNU Texinfo / makeinfo: <div class="footnotes-segment"> with a heading per
+			// footnote — <h5 class="footnote-body-heading"><a id="FOOTn" href="#DOCFn">(n)</a></h5>
+			// followed by the body <p>. Inline markers (<a class="footnote" id="DOCFn"
+			// href="#FOOTn">) reference the heading anchor id, so register under that id.
+			if (list.matches('div.footnotes-segment')) {
+				const headings = list.querySelectorAll('h5.footnote-body-heading');
+				headings.forEach((heading: any) => {
+					const id = (heading.querySelector('a[id]')?.id || '').toLowerCase();
+					if (!id) return;
+					const contentDiv = element.ownerDocument.createElement('div');
+					let sibling = heading.nextElementSibling;
+					while (sibling && !(sibling.tagName.toLowerCase() === 'h5'
+						&& sibling.classList?.contains('footnote-body-heading'))) {
+						if (sibling.textContent?.trim() || sibling.querySelector?.('img, br')) {
+							contentDiv.appendChild(sibling.cloneNode(true));
+						}
+						sibling = sibling.nextElementSibling;
+					}
+					this.addFootnote(state, id, contentDiv);
+				});
+				this.pendingRemovals.push(list);
+				return;
+			}
+
 			// Substack has individual footnote divs with no parent
 			if (list.matches('div.footnote[data-component-name="FootnoteToDOM"]')) {
 				const anchor = list.querySelector('a.footnote-number');

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -128,8 +128,11 @@ export function createMarkdownContent(content: string, url: string) {
 				return handleNestedEquations(node);
 			}
 
-			// Detect layout tables (used for styling/positioning, not data)
-			const hasNestedTables = node.querySelector('table') !== null;
+			// Detect layout tables (used for styling/positioning, not data).
+			// Exclude the node itself: turndown's DOM has a non-spec querySelector that
+			// matches the context element, so `node.querySelector('table')` returns the
+			// table itself — querySelectorAll with a self-filter finds only true nesting.
+			const hasNestedTables = Array.from(node.querySelectorAll('table')).some((t: any) => t !== node);
 			const directCells = Array.from(node.querySelectorAll('td, th')).filter(
 				(el: any) => isDirectTableChild(el, node)
 			);
@@ -145,8 +148,12 @@ export function createMarkdownContent(content: string, url: string) {
 					&& new Set(cellCounts).size === 1
 					&& cellCounts[0] <= 1;
 
-				if (isSingleColumn) {
-					// Layout table — extract content, don't convert to markdown table
+				// Layout tables are used for positioning, not data: a single column, or
+				// any table whose cells embed nested tables (real data tables don't). In
+				// both cases flatten the cells' content — each nested data table is then
+				// rendered as its own markdown table — instead of emitting a broken,
+				// pipe-escaped row (#300). Multi-column layout cells read left-to-right.
+				if (isSingleColumn || hasNestedTables) {
 					return '\n\n' + turndownService.turndown(
 						directCells.map((cell: any) => serializeHTML(cell)).join('')
 					) + '\n\n';

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -118,6 +118,16 @@ export function createMarkdownContent(content: string, url: string) {
 		preformattedCode: true,
 	});
 
+	// Escape tag-like sequences (e.g. a post titled "Monte<video>") in text nodes so
+	// CommonMark renderers such as Obsidian don't parse them as raw HTML and swallow the
+	// following content (#285). Only escape "<" that opens an HTML tag — a name directly
+	// followed by whitespace, "/", or ">". Email/URL autolinks like <a@b.com> or
+	// <https://x> have "@"/":" after the name and are left intact, as is "a < b". Real
+	// kept elements (video/iframe/svg/…) are DOM nodes, not text, so keep rules are safe.
+	const baseEscape = (turndownService.escape as (s: string) => string).bind(turndownService);
+	turndownService.escape = (s: string) =>
+		baseEscape(s).replace(/<(?=\/?[A-Za-z][A-Za-z0-9-]*(?:\s|\/?>))/g, '\\<');
+
 	turndownService.addRule('table', {
 		filter: 'table',
 		replacement: function(content, node) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -562,21 +562,36 @@ export class MetadataExtractor {
 		]);
 		if (result) return result;
 
-		// Look for date text near the article heading
+		// Look for date text near the article heading. Scan both directions:
+		// many layouts put the date in a byline below the <h1>, but others (e.g.
+		// openai.com) place it in a header block immediately above the title.
 		const h1 = doc.querySelector('h1');
 		if (h1) {
-			let sibling = h1.nextElementSibling;
-			for (let i = 0; i < 3 && sibling; i++) {
-				// Check individual children first — some DOMs (e.g. linkedom) omit whitespace
-				// between elements, which breaks word-boundary matching on combined text
-				for (const child of Array.from(sibling.querySelectorAll('p, time'))) {
-					const parsed = this.parseDateText(child.textContent?.trim() || '');
-					if (parsed) return parsed;
+			const scan = (start: Element | null, step: (el: Element) => Element | null, childrenOnly: boolean): string => {
+				let sibling = start;
+				for (let i = 0; i < 3 && sibling; i++) {
+					// Check individual children first — some DOMs (e.g. linkedom) omit whitespace
+					// between elements, which breaks word-boundary matching on combined text
+					for (const child of Array.from(sibling.querySelectorAll('p, time'))) {
+						const parsed = this.parseDateText(child.textContent?.trim() || '');
+						if (parsed) return parsed;
+					}
+					// Above the title, only trust dates in explicit <p>/<time> elements:
+					// header blocks there mix in breadcrumbs/categories whose loose text
+					// (e.g. "Blog | March 1, 2026") is navigation, not the article's date.
+					if (!childrenOnly) {
+						const parsed = this.parseDateText(sibling.textContent?.trim() || '');
+						if (parsed) return parsed;
+					}
+					sibling = step(sibling);
 				}
-				const parsed = this.parseDateText(sibling.textContent?.trim() || '');
-				if (parsed) return parsed;
-				sibling = sibling.nextElementSibling;
-			}
+				return '';
+			};
+			const found = this.firstValid([
+				() => scan(h1.nextElementSibling, el => el.nextElementSibling, false),
+				() => scan(h1.previousElementSibling, el => el.previousElementSibling, true),
+			]);
+			if (found) return found;
 		}
 
 		return '';

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -56,7 +56,7 @@ export class MetadataExtractor {
 			favicon: this.getFavicon(doc, url, metaTags),
 			image: this.getImage(doc, schemaOrgData, metaTags),
 			language: this.getLanguage(doc, schemaOrgData, metaTags),
-			published: this.getPublished(doc, schemaOrgData, metaTags),
+			published: this.getPublished(doc, schemaOrgData, metaTags, url),
 			author,
 			site,
 			schemaOrgData,
@@ -551,13 +551,13 @@ export class MetadataExtractor {
 		return '';
 	}
 
-	private static getPublished(doc: Document, schemaOrgData: any, metaTags: MetaTagItem[]): string {
+	private static getPublished(doc: Document, schemaOrgData: any, metaTags: MetaTagItem[], url: string): string {
 		const result = this.firstValid([
 			() => this.getSchemaProperty(schemaOrgData, 'datePublished'),
 			() => this.getMetaContent(metaTags, "name", "publishDate"),
 			() => this.getMetaContent(metaTags, "property", "article:published_time"),
 			() => (doc.querySelector('abbr[itemprop="datePublished"]') as HTMLElement)?.title?.trim() || '',
-			() => this.getTimeElement(doc),
+			() => this.getTimeElement(doc, url),
 			() => this.getMetaContent(metaTags, "name", "sailthru.date"),
 		]);
 		if (result) return result;
@@ -593,11 +593,38 @@ export class MetadataExtractor {
 		}).map(tag => tag.content?.trim() ?? "");
 	}
 
-	private static getTimeElement(doc: Document): string {
-		const selector = `time`;
-		const element = Array.from(doc.querySelectorAll(selector))[0];
-		const content = element ? (element.getAttribute("datetime")?.trim() ?? element.textContent?.trim() ?? "") : "";
-		return content;
+	private static getTimeElement(doc: Document, url: string): string {
+		// Skip <time> elements that belong to a link pointing at a different page —
+		// related/suggested-post cards wrap their own date in an <a>, and that date is
+		// not the current article's (see #295, openai.com blog).
+		for (const element of Array.from(doc.querySelectorAll('time'))) {
+			if (this.isLinkedToOtherPage(element, url)) continue;
+			const content = element.getAttribute("datetime")?.trim() || element.textContent?.trim() || "";
+			if (content) return content;
+		}
+		return "";
+	}
+
+	// True when `el` sits inside an <a> linking to another page on the SAME site —
+	// i.e. a related/suggested-post card whose date is not the current article's
+	// (see #295, openai.com). Links to the same page (self/permalink, in-page anchor)
+	// and links to external sites (e.g. an article date that links to its social-media
+	// thread) are kept, since those still describe the current article.
+	private static isLinkedToOtherPage(el: Element, pageUrl: string): boolean {
+		if (!pageUrl) return false;
+		const anchor = el.closest('a[href]');
+		if (!anchor) return false;
+		const href = anchor.getAttribute('href')?.trim() || '';
+		if (!href || href.startsWith('#')) return false;
+		try {
+			const target = new URL(href, pageUrl);
+			const current = new URL(pageUrl);
+			if (target.origin !== current.origin) return false; // external link — keep
+			const norm = (p: string) => p.replace(/\/+$/, '');
+			return norm(target.pathname) !== norm(current.pathname);
+		} catch {
+			return false;
+		}
 	}
 
 	private static readonly MONTH_MAP: Record<string, string> = {

--- a/src/removals/scoring.ts
+++ b/src/removals/scoring.ts
@@ -282,6 +282,16 @@ export class ContentScorer {
 				return;
 			}
 
+			// Skip elements inside table cells — a cell's content is structural, not a
+			// standalone navigation block, and removing individual cells leaves the table
+			// malformed. The table element itself is still scored as a whole, so genuine
+			// navigation tables are still removed. Common-word navigation indicators such
+			// as "header" otherwise strip legitimate cells (e.g. cppreference's
+			// "Defined in header <cstddef>" declaration rows, #284).
+			if (element.closest('td, th')) {
+				return;
+			}
+
 			// Skip elements that are likely to be content
 			if (ContentScorer.isLikelyContent(element)) {
 				return;

--- a/tests/conversation-linkedom.test.ts
+++ b/tests/conversation-linkedom.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect, vi } from 'vitest';
+import { Defuddle } from '../src/node';
+import { parseLinkedomHTML } from '../src/utils/linkedom-compat';
+
+/**
+ * Regression test for #298.
+ *
+ * ConversationExtractor.extract() builds a scratch document to re-clean the
+ * formatted message HTML. linkedom does not provide
+ * `document.implementation.createHTMLDocument`, so the extractor must fall back
+ * to `document.defaultView.DOMParser`. Before the fallback existed the extractor
+ * threw `TypeError: undefined is not an object (evaluating
+ * 'this.document.implementation.createHTMLDocument')`, logged a stack trace via
+ * console.error, and silently fell back to the generic extractor.
+ */
+describe('ConversationExtractor on linkedom (#298)', () => {
+	test('Claude share page extracts without crashing and uses the conversation extractor', async () => {
+		const html = `<!doctype html><html><body>
+			<div data-testid="user-message"><p>What is RAG?</p></div>
+			<div class="font-claude-response"><div class="standard-markdown">
+				<p>${'Retrieval augmented generation grounds the model. '.repeat(20)}</p>
+			</div></div>
+		</body></html>`;
+
+		const doc = parseLinkedomHTML(html, 'https://claude.ai/share/abc');
+
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const result = await Defuddle(doc, 'https://claude.ai/share/abc', { markdown: false });
+
+			// The extractor must not log a createHTMLDocument crash.
+			const loggedCrash = errorSpy.mock.calls
+				.flat()
+				.some((arg) => String(arg).includes('createHTMLDocument'));
+			expect(loggedCrash).toBe(false);
+
+			// Conversation extractor output: both turns present, in order.
+			expect(result.content).toContain('You');
+			expect(result.content).toContain('Claude');
+			expect(result.content).toContain('What is RAG?');
+			expect(result.content).toContain('Retrieval augmented generation');
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+});

--- a/tests/expected/issues--280-texinfo-footnotes.md
+++ b/tests/expected/issues--280-texinfo-footnotes.md
@@ -1,0 +1,40 @@
+```json
+{
+  "title": "Introduction (Widget)",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+## 1 Introduction
+
+Widget is a symlink farm manager which takes distinct sets of software and/or data located in separate directories on the filesystem, and makes them all appear to be installed in a single directory tree.
+
+Originally Widget was born to address the need to administer, upgrade, install, and remove files in independent software packages without confusing them with other files sharing the same file system space. For instance, many years ago it used to be common to compile programs from source and install them in /usr/local. When one does so, one winds up with the following files [^1] in /usr/local/man/man1:
+
+```
+a2p.1
+ctags.1
+emacs.1
+etags.1
+h2ph.1
+perl.1
+s2p.1
+```
+
+Now suppose it’s time to uninstall a package. Which man pages get removed? It should not be the administrator’s responsibility to memorize the ownership of individual files by separate packages.
+
+The approach used by Widget is to install each package into its own tree, then use symbolic links to make it appear as though the files are installed in the common tree. Administration can be performed in the package’s private tree in isolation from clutter from other packages. Widget can then be used to update the symbolic links.
+
+However Widget is still used not only for software package management, but also for other purposes, such as facilitating a more controlled approach to management of configuration files in the user’s home directory [^2], especially when coupled with version control systems [^3].
+
+Widget stores no extra state between runs, so there’s no danger of mangling directories when file hierarchies don’t match a database. Widget will never delete any files, directories, or links that appear in a Widget directory, so it’s always possible to rebuild the target tree.
+
+---
+
+[^1]: As of an ancient release. These are now old versions but the example still holds valid.
+
+[^2]: [https://www.example.com/news/using-widget-to-manage-your-dotfiles.html](https://www.example.com/news/using-widget-to-manage-your-dotfiles.html)
+
+[^3]: [https://lists.example.com/archive/html/info-widget/msg00000.html](https://lists.example.com/archive/html/info-widget/msg00000.html)

--- a/tests/expected/issues--284-table-cell-header-scoring.md
+++ b/tests/expected/issues--284-table-cell-header-scoring.md
@@ -1,0 +1,23 @@
+```json
+{
+  "title": "example_size_t - Reference",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+## example::size\_t
+
+| Defined in header `<cstddef>` |  |  |
+| --- | --- | --- |
+| Defined in header `<cstdlib>` |  |  |
+| ``` typedef /* implementation-defined */ size_t; ``` |  | (since C++17) |
+
+`example::size_t` is the unsigned integer type of the result of the `sizeof` operator. It is widely used to represent sizes and counts in portable code, and it can store the maximum size of any theoretically possible object on the target platform regardless of its declared type.
+
+`example::size_t` is commonly used for array indexing and loop counting. Programs that use other types for array indexing may fail on large systems when the index exceeds the range those narrower types can represent without overflow.
+
+### Notes
+
+On most platforms `example::size_t` can safely store the value of any non-member pointer, in which case it is as wide as the platform's pointer type and can round-trip pointer values through integer arithmetic without loss of information.

--- a/tests/expected/issues--285-tag-like-title-escaping.md
+++ b/tests/expected/issues--285-tag-like-title-escaping.md
@@ -1,0 +1,34 @@
+```json
+{
+  "title": "Blog Posts",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+This is a list of blog posts. One of the titles contains angle brackets that look like an HTML tag, which must be escaped so a Markdown reader does not treat it as raw HTML and swallow everything that follows it on the page.
+
+[![blog cover](https://www.example.com/blog/first-post/cover.png)](https://www.example.com/blog/first-post)
+
+[An Ordinary First Post](https://www.example.com/blog/first-post)
+
+A gentle introduction with nothing unusual in its title at all.
+
+by author
+
+[![blog cover](https://www.example.com/blog/monte-video/cover.png)](https://www.example.com/blog/monte-video)
+
+[Monte\<video>: A Real Place](https://www.example.com/blog/monte-video)
+
+A post whose title embeds a tag-like token. Reach us at <hello@example.com>.
+
+by author
+
+[![blog cover](https://www.example.com/blog/third-post/cover.png)](https://www.example.com/blog/third-post)
+
+[A Third Post Worth Reading](https://www.example.com/blog/third-post)
+
+The final entry, included so there is content after the tricky title.
+
+by author

--- a/tests/expected/issues--286-generic-alt-image-dedup.md
+++ b/tests/expected/issues--286-generic-alt-image-dedup.md
@@ -1,0 +1,32 @@
+```json
+{
+  "title": "AI Voice Tutorial",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+This walkthrough shows each step of the workflow with a screenshot. The screenshots all share the same generic alt text because the CMS assigns it automatically, but every one is a distinct image with its own URL and should be preserved in the output.
+
+First, open the dashboard and create a new project from the home screen so the workspace is ready before importing any audio.
+
+![image](https://image.example.com/2026/04/step_1.png)
+
+Next, upload your source recording and wait for the analysis pass to finish before continuing to the voice settings panel.
+
+![image](https://image.example.com/2026/04/step_2.png)
+
+Then adjust the stability and clarity sliders until the preview sounds natural for your narration use case and target audience.
+
+![image](https://image.example.com/2026/04/step_3.png)
+
+After that, generate the full render and review the waveform for any clipping or artifacts introduced during synthesis.
+
+![image](https://image.example.com/2026/04/step_4.png)
+
+Finally, export the finished audio in your preferred format and download it for use in your video editor or podcast tool.
+
+![image](https://image.example.com/2026/04/step_5.png)
+
+That completes the tutorial. Each screenshot above documents a separate stage of the process from start to finish.

--- a/tests/expected/issues--296-oreilly-noteref-footnotes.md
+++ b/tests/expected/issues--296-oreilly-noteref-footnotes.md
@@ -1,0 +1,37 @@
+```json
+{
+  "title": "Sample Chapter",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+## 2\. Sample Chapter
+
+This chapter demonstrates a few language constructs. Numeric conversions from one representation to another are usually straightforward, although very large values can occasionally lose precision when widened to another numeric type.[^1] The compiler applies these conversions automatically where it is safe to do so.
+
+Comparison operators normally return a boolean result, and it is uncommon to define them otherwise.[^2] Most code relies on the default behavior without any customization at all.
+
+The `ref` modifier is essential in implementing a swap method (in ["Generics"](https://www.example.com/library/view/sample-book/ch03.html#generics), we show how to write a swap method that works with any type):
+
+```
+string x = "Penn";
+string y = "Teller";
+Swap (ref x, ref y);
+Console.WriteLine (x);   // Teller
+Console.WriteLine (y);   // Penn
+
+static void Swap (ref string a, ref string b)
+{
+  string temp = a;
+  a = b;
+  b = temp;
+}
+```
+
+After the swap completes, the two variables have exchanged their contents, which illustrates how arguments are passed by reference rather than by value in this example. This paragraph exists so the chapter body has enough surrounding prose for the content extractor to score it as the main content.
+
+[^1]: A minor caveat is that very large values lose some precision when converted to another numeric type.
+
+[^2]: An exception is when calling certain interop methods, discussed in a later chapter.

--- a/tests/expected/issues--300-nested-layout-tables.md
+++ b/tests/expected/issues--300-nested-layout-tables.md
@@ -1,0 +1,43 @@
+```json
+{
+  "title": "Overview of shortcuts",
+  "author": "",
+  "site": "",
+  "published": ""
+}
+```
+
+## Overview of the editor's shortcuts
+
+### The keystrokes and their functions
+
+**File handling**
+
+| Ctrl+S | Save current file |
+| --- | --- |
+| Ctrl+O | Offer to write file ("Save as") |
+| Ctrl+R | Insert a file into current one |
+| Ctrl+X | Close buffer, exit from the editor |
+
+  
+**Editing**
+
+| Ctrl+K | Cut current line into cutbuffer |
+| --- | --- |
+| Alt+6 | Copy current line into cutbuffer |
+| Ctrl+U | Paste contents of cutbuffer |
+
+**Moving around**
+
+| Ctrl+A | To start of line |
+| --- | --- |
+| Ctrl+E | To end of line |
+| Ctrl+P | One line up |
+| Ctrl+N | One line down |
+
+  
+**Information**
+
+| Ctrl+C | Report cursor position |
+| --- | --- |
+| Alt+D | Report line/word/character count |

--- a/tests/expected/metadata--295-header-date-above-title.md
+++ b/tests/expected/metadata--295-header-date-above-title.md
@@ -1,0 +1,14 @@
+```json
+{
+  "title": "Example Company named a Leader in enterprise coding agents",
+  "author": "",
+  "site": "Example Company",
+  "published": "2026-05-22T00:00:00+00:00"
+}
+```
+
+Example Company is named a leader in the 2026 industry report for enterprise AI coding agents, with its product recognized for innovation and enterprise-scale deployment.
+
+The recognition reflects sustained investment in reliability, security, and the developer experience across large organizations adopting agentic coding workflows.
+
+Customers cite measurable gains in review throughput and a reduction in time spent on routine refactoring tasks after rolling out the tooling to their engineering teams.

--- a/tests/expected/metadata--295-suggested-post-date.md
+++ b/tests/expected/metadata--295-suggested-post-date.md
@@ -1,0 +1,14 @@
+```json
+{
+  "title": "Example Company named a Leader in enterprise coding agents",
+  "author": "",
+  "site": "Example Company",
+  "published": "2026-05-22T00:00:00+00:00"
+}
+```
+
+Example Company is named a leader in the 2026 industry report for enterprise AI coding agents, with its product recognized for innovation and enterprise-scale deployment.
+
+The recognition reflects sustained investment in reliability, security, and the developer experience across large organizations adopting agentic coding workflows.
+
+Customers cite measurable gains in review throughput and a reduction in time spent on routine refactoring tasks after rolling out the tooling to their engineering teams.

--- a/tests/fixtures/issues--280-texinfo-footnotes.html
+++ b/tests/fixtures/issues--280-texinfo-footnotes.html
@@ -1,0 +1,92 @@
+<!-- {"url":"https://www.example.org/software/widget/manual/html_node/Introduction.html"} -->
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Introduction (Widget)</title>
+<meta name="description" content="Introduction (Widget)">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link href="index.html" rel="start" title="Top">
+<link href="Terminology.html" rel="next" title="Terminology">
+</head>
+
+<body lang="en">
+<div class="chapter-level-extent" id="Introduction">
+<div class="nav-panel">
+<p>
+Next: <a href="Terminology.html" accesskey="n" rel="next">Terminology</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="chapter" id="Introduction-1">1 Introduction</h2>
+
+<p>Widget is a symlink farm manager which takes distinct sets of
+software and/or data located in separate directories on the
+filesystem, and makes them all appear to be installed in a single
+directory tree.
+</p>
+<p>Originally Widget was born to address the need to administer, upgrade,
+install, and remove files in independent software packages without
+confusing them with other files sharing the same file system space.
+For instance, many years ago it used to be common to compile programs
+from source and install them in
+<samp class="file">/usr/local</samp>.  When one does so, one winds up with the following
+files<a class="footnote" id="DOCF1" href="#FOOT1"><sup>1</sup></a> in
+<samp class="file">/usr/local/man/man1</samp>:
+</p>
+<div class="example">
+<pre class="example-preformatted">a2p.1
+ctags.1
+emacs.1
+etags.1
+h2ph.1
+perl.1
+s2p.1
+</pre></div>
+
+<p>Now suppose it&rsquo;s time to uninstall a package.  Which man pages
+get removed?  It should not be the administrator&rsquo;s responsibility
+to memorize the ownership of individual files by separate packages.
+</p>
+<p>The approach used by Widget is to install each package into its own
+tree, then use symbolic links to make it appear as though the files are
+installed in the common tree.  Administration can be performed in the
+package&rsquo;s private tree in isolation from clutter from other packages.
+Widget can then be used to update the symbolic links.
+</p>
+<p>However Widget is still used not only for software package management,
+but also for other purposes, such as facilitating a more controlled
+approach to management of configuration files in the user&rsquo;s home
+directory<a class="footnote" id="DOCF2" href="#FOOT2"><sup>2</sup></a>,
+especially when coupled with version control
+systems<a class="footnote" id="DOCF3" href="#FOOT3"><sup>3</sup></a>.
+</p>
+<p>Widget stores no extra state between runs, so there&rsquo;s no danger of
+mangling directories when file hierarchies don&rsquo;t match a database.
+Widget will never delete any files, directories, or links that appear in
+a Widget directory, so it&rsquo;s always possible to rebuild the target tree.
+</p>
+
+</div>
+<div class="footnotes-segment">
+<hr>
+<h4 class="footnotes-heading">Footnotes</h4>
+
+<h5 class="footnote-body-heading"><a id="FOOT1" href="#DOCF1">(1)</a></h5>
+<p>As of an ancient release. These are now old versions but the example still holds valid.</p>
+<h5 class="footnote-body-heading"><a id="FOOT2" href="#DOCF2">(2)</a></h5>
+<p><a class="uref" href="https://www.example.com/news/using-widget-to-manage-your-dotfiles.html">https://www.example.com/news/using-widget-to-manage-your-dotfiles.html</a></p>
+<h5 class="footnote-body-heading"><a id="FOOT3" href="#DOCF3">(3)</a></h5>
+<p><a class="uref" href="https://lists.example.com/archive/html/info-widget/msg00000.html">https://lists.example.com/archive/html/info-widget/msg00000.html</a></p>
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Terminology.html">Terminology</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/tests/fixtures/issues--284-table-cell-header-scoring.html
+++ b/tests/fixtures/issues--284-table-cell-header-scoring.html
@@ -1,0 +1,30 @@
+<!-- {"url":"https://www.example.com/reference/types/size_t"} -->
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>example_size_t - Reference</title></head>
+<body>
+<div id="content">
+	<h1>example::size_t</h1>
+
+	<table class="t-dcl-begin"><tbody>
+		<tr class="t-dsc-header"><td><div>Defined in header <code>&lt;cstddef&gt;</code></div></td><td></td><td></td></tr>
+		<tr class="t-dsc-header"><td><div>Defined in header <code>&lt;cstdlib&gt;</code></div></td><td></td><td></td></tr>
+		<tr class="t-dcl"><td><div><pre>typedef /* implementation-defined */ size_t;</pre></div></td><td></td><td><div>(since C++17)</div></td></tr>
+	</tbody></table>
+
+	<p><code>example::size_t</code> is the unsigned integer type of the result of the
+	<code>sizeof</code> operator. It is widely used to represent sizes and counts in
+	portable code, and it can store the maximum size of any theoretically possible
+	object on the target platform regardless of its declared type.</p>
+
+	<p><code>example::size_t</code> is commonly used for array indexing and loop counting.
+	Programs that use other types for array indexing may fail on large systems when the
+	index exceeds the range those narrower types can represent without overflow.</p>
+
+	<h3>Notes</h3>
+	<p>On most platforms <code>example::size_t</code> can safely store the value of any
+	non-member pointer, in which case it is as wide as the platform's pointer type and
+	can round-trip pointer values through integer arithmetic without loss of information.</p>
+</div>
+</body>
+</html>

--- a/tests/fixtures/issues--285-tag-like-title-escaping.html
+++ b/tests/fixtures/issues--285-tag-like-title-escaping.html
@@ -1,0 +1,42 @@
+<!-- {"url":"https://www.example.com/blog/"} -->
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Blog Posts</title></head>
+<body>
+<article class="markdown">
+	<section>
+		<h1>Blog Posts</h1>
+		<p>This is a list of blog posts. One of the titles contains angle brackets that
+		look like an HTML tag, which must be escaped so a Markdown reader does not treat
+		it as raw HTML and swallow everything that follows it on the page.</p>
+
+		<article>
+			<a href="/blog/first-post"><img src="/blog/first-post/cover.png" alt="blog cover"></a>
+			<div>
+				<a href="/blog/first-post">An Ordinary First Post</a>
+				<div>A gentle introduction with nothing unusual in its title at all.</div>
+				<div>by author</div>
+			</div>
+		</article>
+
+		<article>
+			<a href="/blog/monte-video"><img src="/blog/monte-video/cover.png" alt="blog cover"></a>
+			<div>
+				<a href="/blog/monte-video">Monte&lt;video&gt;: A Real Place</a>
+				<div>A post whose title embeds a tag-like token. Reach us at &lt;hello@example.com&gt;.</div>
+				<div>by author</div>
+			</div>
+		</article>
+
+		<article>
+			<a href="/blog/third-post"><img src="/blog/third-post/cover.png" alt="blog cover"></a>
+			<div>
+				<a href="/blog/third-post">A Third Post Worth Reading</a>
+				<div>The final entry, included so there is content after the tricky title.</div>
+				<div>by author</div>
+			</div>
+		</article>
+	</section>
+</article>
+</body>
+</html>

--- a/tests/fixtures/issues--286-generic-alt-image-dedup.html
+++ b/tests/fixtures/issues--286-generic-alt-image-dedup.html
@@ -1,0 +1,30 @@
+<!-- {"url":"https://www.example.com/elevenlabs-ai-voice-tutorial/"} -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>AI Voice Tutorial</title>
+</head>
+<body>
+	<article>
+		<h1>AI Voice Tutorial</h1>
+		<p>This walkthrough shows each step of the workflow with a screenshot. The screenshots all share the same generic alt text because the CMS assigns it automatically, but every one is a distinct image with its own URL and should be preserved in the output.</p>
+
+		<p>First, open the dashboard and create a new project from the home screen so the workspace is ready before importing any audio.</p>
+		<img alt="image" src="https://image.example.com/2026/04/step_1.png">
+
+		<p>Next, upload your source recording and wait for the analysis pass to finish before continuing to the voice settings panel.</p>
+		<img alt="image" src="https://image.example.com/2026/04/step_2.png">
+
+		<p>Then adjust the stability and clarity sliders until the preview sounds natural for your narration use case and target audience.</p>
+		<img alt="image" src="https://image.example.com/2026/04/step_3.png">
+
+		<p>After that, generate the full render and review the waveform for any clipping or artifacts introduced during synthesis.</p>
+		<img alt="image" src="https://image.example.com/2026/04/step_4.png">
+
+		<p>Finally, export the finished audio in your preferred format and download it for use in your video editor or podcast tool.</p>
+		<img alt="image" src="https://image.example.com/2026/04/step_5.png">
+
+		<p>That completes the tutorial. Each screenshot above documents a separate stage of the process from start to finish.</p>
+	</article>
+</body>
+</html>

--- a/tests/fixtures/issues--296-oreilly-noteref-footnotes.html
+++ b/tests/fixtures/issues--296-oreilly-noteref-footnotes.html
@@ -1,0 +1,49 @@
+<!-- {"url":"https://www.example.com/library/view/sample-book/ch02.html"} -->
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Sample Chapter</title>
+</head>
+<body data-type="book">
+<section data-type="chapter">
+	<h1>2. Sample Chapter</h1>
+
+	<p>This chapter demonstrates a few language constructs. Numeric conversions
+	from one representation to another are usually straightforward, although very
+	large values can occasionally lose precision when widened to another numeric
+	type.<sup><a data-type="noteref" href="ch02.html#fn1" id="fn1-marker">1</a></sup>
+	The compiler applies these conversions automatically where it is safe to do so.</p>
+
+	<p>Comparison operators normally return a boolean result, and it is uncommon to
+	define them otherwise.<sup><a data-type="noteref" href="ch02.html#fn2" id="fn2-marker">2</a></sup>
+	Most code relies on the default behavior without any customization at all.</p>
+
+	<p>The <code>ref</code> modifier is essential in implementing a swap method (in
+	<a data-type="xref" href="ch03.html#generics">"Generics"</a>, we show how to write
+	a swap method that works with any type):</p>
+	<pre data-type="programlisting">string x = "Penn";
+string y = "Teller";
+Swap (ref x, ref y);
+Console.WriteLine (x);   // Teller
+Console.WriteLine (y);   // Penn
+
+static void Swap (ref string a, ref string b)
+{
+  string temp = a;
+  a = b;
+  b = temp;
+}</pre>
+
+	<p>After the swap completes, the two variables have exchanged their contents,
+	which illustrates how arguments are passed by reference rather than by value in
+	this example. This paragraph exists so the chapter body has enough surrounding
+	prose for the content extractor to score it as the main content.</p>
+
+	<div data-type="footnotes">
+		<p data-type="footnote" id="fn1"><sup><a href="ch02.html#fn1-marker">1</a></sup> A minor caveat is that very large values lose some precision when converted to another numeric type.</p>
+		<p data-type="footnote" id="fn2"><sup><a href="ch02.html#fn2-marker">2</a></sup> An exception is when calling certain interop methods, discussed in a later chapter.</p>
+	</div>
+</section>
+</body>
+</html>

--- a/tests/fixtures/issues--300-nested-layout-tables.html
+++ b/tests/fixtures/issues--300-nested-layout-tables.html
@@ -1,0 +1,49 @@
+<!-- {"url":"https://www.example.org/cheatsheet.html"} -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Overview of shortcuts</title></head>
+<body>
+<h1 align="center">Overview of the editor's shortcuts</h1>
+<h3 align="center">The keystrokes and their functions</h3>
+
+<table align="center"><tbody>
+<tr><td>
+
+<b>File handling</b>
+<table><tbody>
+<tr><td>Ctrl+S &nbsp;&nbsp;</td><td>Save current file</td></tr>
+<tr><td>Ctrl+O</td><td>Offer to write file ("Save as")</td></tr>
+<tr><td>Ctrl+R</td><td>Insert a file into current one</td></tr>
+<tr><td>Ctrl+X</td><td>Close buffer, exit from the editor</td></tr>
+</tbody></table>
+<br>
+
+<b>Editing</b>
+<table><tbody>
+<tr><td>Ctrl+K &nbsp;&nbsp;</td><td>Cut current line into cutbuffer</td></tr>
+<tr><td>Alt+6</td><td>Copy current line into cutbuffer</td></tr>
+<tr><td>Ctrl+U</td><td>Paste contents of cutbuffer</td></tr>
+</tbody></table>
+
+</td><td>
+
+<b>Moving around</b>
+<table><tbody>
+<tr><td>Ctrl+A &nbsp;&nbsp;</td><td>To start of line</td></tr>
+<tr><td>Ctrl+E</td><td>To end of line</td></tr>
+<tr><td>Ctrl+P</td><td>One line up</td></tr>
+<tr><td>Ctrl+N</td><td>One line down</td></tr>
+</tbody></table>
+<br>
+
+<b>Information</b>
+<table><tbody>
+<tr><td>Ctrl+C &nbsp;&nbsp;</td><td>Report cursor position</td></tr>
+<tr><td>Alt+D</td><td>Report line/word/character count</td></tr>
+</tbody></table>
+
+</td></tr>
+</tbody></table>
+
+</body>
+</html>

--- a/tests/fixtures/metadata--295-header-date-above-title.html
+++ b/tests/fixtures/metadata--295-header-date-above-title.html
@@ -1,0 +1,38 @@
+<!--{"url":"https://example.com/index/example-article/"}-->
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+	<meta charset="utf-8">
+	<title>Example Company named a Leader in enterprise coding agents</title>
+	<link rel="canonical" href="https://example.com/index/example-article/">
+	<meta property="og:url" content="https://example.com/index/example-article/">
+	<meta property="og:site_name" content="Example Company">
+</head>
+<body>
+	<main>
+		<article>
+			<!-- Header block above the title holds the date in a <p>, alongside a category link.
+			     Mirrors openai.com, where the published date precedes the <h1> (see #295). -->
+			<div class="header flex flex-wrap justify-center">
+				<p class="text-meta">May 22, 2026</p>
+				<a href="/news/ai-adoption/">AI Adoption</a>
+			</div>
+			<h1>Example Company named a Leader in enterprise coding agents</h1>
+			<p>Example Company is named a leader in the 2026 industry report for enterprise AI coding agents, with its product recognized for innovation and enterprise-scale deployment.</p>
+			<p>The recognition reflects sustained investment in reliability, security, and the developer experience across large organizations adopting agentic coding workflows.</p>
+			<p>Customers cite measurable gains in review throughput and a reduction in time spent on routine refactoring tasks after rolling out the tooling to their engineering teams.</p>
+		</article>
+		<aside aria-label="More posts">
+			<h2>Latest news</h2>
+			<a href="/index/another-suggested-post/">
+				<time datetime="2026-03-05T00:00">Mar 5, 2026</time>
+				<span>A different article you might also like</span>
+			</a>
+			<a href="/index/yet-another-post/">
+				<time datetime="2026-02-18T00:00">Feb 18, 2026</time>
+				<span>Yet another related article</span>
+			</a>
+		</aside>
+	</main>
+</body>
+</html>

--- a/tests/fixtures/metadata--295-suggested-post-date.html
+++ b/tests/fixtures/metadata--295-suggested-post-date.html
@@ -1,0 +1,33 @@
+<!--{"url":"https://example.com/index/example-article/"}-->
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+	<meta charset="utf-8">
+	<title>Example Company named a Leader in enterprise coding agents</title>
+	<link rel="canonical" href="https://example.com/index/example-article/">
+	<meta property="og:url" content="https://example.com/index/example-article/">
+	<meta property="og:site_name" content="Example Company">
+</head>
+<body>
+	<main>
+		<article>
+			<h1>Example Company named a Leader in enterprise coding agents</h1>
+			<p class="byline">Published May 22, 2026</p>
+			<p>Example Company is named a leader in the 2026 industry report for enterprise AI coding agents, with its product recognized for innovation and enterprise-scale deployment.</p>
+			<p>The recognition reflects sustained investment in reliability, security, and the developer experience across large organizations adopting agentic coding workflows.</p>
+			<p>Customers cite measurable gains in review throughput and a reduction in time spent on routine refactoring tasks after rolling out the tooling to their engineering teams.</p>
+		</article>
+		<aside aria-label="More posts">
+			<h2>Latest news</h2>
+			<a href="/index/another-suggested-post/">
+				<time datetime="2026-03-05T00:00">Mar 5, 2026</time>
+				<span>A different article you might also like</span>
+			</a>
+			<a href="/index/yet-another-post/">
+				<time datetime="2026-02-18T00:00">Feb 18, 2026</time>
+				<span>Yet another related article</span>
+			</a>
+		</aside>
+	</main>
+</body>
+</html>


### PR DESCRIPTION
Batch of independent extraction fixes:

- **#295** — Published date: skip suggested/related-post `<time>` cards, and read the date from a header block above the title (e.g. openai.com) instead of returning empty.
- **#286** — Only dedupe truly adjacent lazy-load images, not distinct images that happen to share alt text.
- **#284** — Stop score-removing content inside table cells (`<td>`/`<th>`), which emptied cppreference declaration rows.
- **#300** — Flatten layout tables with nested tables instead of rendering them as rows of escaped pipes.
- **#285** — Escape tag-like text (e.g. `Monte<video>`) so renderers don't treat it as raw HTML.
- **#296** — Handle O'Reilly/HTMLBook `data-type` footnotes without duplicating body text into footnotes.
- **#280** — Handle GNU Texinfo footnotes (`footnotes-segment`) without duplicating chapter text.
- **#298** — Test coverage: conversation extractors run on a linkedom document without the `createHTMLDocument` crash.