### PR TITLE
Fix lazy-loaded image source extraction

### DIFF
--- a/src/elements/images.ts
+++ b/src/elements/images.ts
@@ -17,6 +17,7 @@ const urlPattern = /^([^\s]+)/;
 const absoluteUrlPattern = /^https?:\/\//;
 const filenamePattern = /^[\w\-\.\/\\]+\.(jpg|jpeg|png|gif|webp|svg)$/i;
 const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+const lazyImageSourceAttributes = ['data-src', 'data-original', 'data-lazy-src', 'data-actualsrc', 'data-backup'];
 
 export const imageRules = [
 	// Handle picture elements first to ensure we get the highest resolution
@@ -142,7 +143,7 @@ export const imageRules = [
 	
 	// Handle lazy-loaded images
 	{
-		selector: 'img[data-src], img[data-srcset], img[loading="lazy"], img.lazy, img.lazyload, img[src^="data:image/svg+xml"]',
+		selector: 'img[data-src], img[data-original], img[data-lazy-src], img[data-actualsrc], img[data-backup], img[data-srcset], img[loading="lazy"], img.lazy, img.lazyload, img[src^="data:image/"]',
 		element: 'img',
 		transform: (el: Element, doc: Document): Element => {
 			// Check for base64 placeholder images
@@ -154,10 +155,13 @@ export const imageRules = [
 				el.removeAttribute('src');
 			}
 
-			// Handle data-src
-			const dataSrc = el.getAttribute('data-src');
-			if (dataSrc && !el.getAttribute('src')) {
-				el.setAttribute('src', dataSrc);
+			// Handle common lazy image source attributes
+			for (const attrName of lazyImageSourceAttributes) {
+				const lazySrc = el.getAttribute(attrName);
+				if (lazySrc && !el.getAttribute('src')) {
+					el.setAttribute('src', lazySrc);
+					break;
+				}
 			}
 
 			// Handle data-srcset
@@ -197,7 +201,7 @@ export const imageRules = [
 			// Remove lazy loading related classes and attributes
 			el.classList.remove('lazy', 'lazyload');
 			el.removeAttribute('data-ll-status');
-			el.removeAttribute('data-src');
+			lazyImageSourceAttributes.forEach(attr => el.removeAttribute(attr));
 			el.removeAttribute('data-srcset');
 			el.removeAttribute('loading');
 			
@@ -408,8 +412,8 @@ function isValidImageUrl(src: string): boolean {
  * Check if an element has better image sources than the current src
  */
 function hasBetterImageSource(element: Element): boolean {
-	// Check for data-src or data-srcset
-	if (element.hasAttribute('data-src') || element.hasAttribute('data-srcset')) {
+	// Check for common lazy image source attributes
+	if (element.hasAttribute('data-srcset') || lazyImageSourceAttributes.some(attr => element.hasAttribute(attr))) {
 		return true;
 	}
 	

--- a/src/removals/small-images.ts
+++ b/src/removals/small-images.ts
@@ -139,7 +139,9 @@ export function removeSmallImages(doc: Document, smallImages: Set<string>, debug
 					element.getAttribute('data-src') ||
 					element.getAttribute('data-srcset') ||
 					element.getAttribute('data-lazy-src') ||
-					element.getAttribute('data-original');
+					element.getAttribute('data-original') ||
+					element.getAttribute('data-actualsrc') ||
+					element.getAttribute('data-backup');
 				if (!src && !hasAltSrc) {
 					element.remove();
 					removedCount++;

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -92,6 +92,22 @@ describe('Markdown conversion', () => {
 		});
 	});
 
+	describe('lazy-loaded images', () => {
+		test.each([
+			'data-original',
+			'data-lazy-src',
+			'data-actualsrc',
+			'data-backup',
+		])('should promote %s when src is a placeholder', async (attribute) => {
+			const placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+			const html = `<html><head><title>Test</title></head><body><article><p>Content</p><img src="${placeholder}" ${attribute}="/images/a.jpg" alt="A"></article></body></html>`;
+			const result = await Defuddle(parseDocument(html, 'https://example.com/articles/post'), 'https://example.com/articles/post', { separateMarkdown: true });
+
+			expect(result.contentMarkdown).toContain('![A](https://example.com/images/a.jpg)');
+			expect(result.contentMarkdown).not.toContain('data:image');
+		});
+	});
+
 	describe('wbr tag handling', () => {
 		test('should remove wbr tags without adding spaces', async () => {
 			const html = `<html><head><title>Test</title></head><body><article><p>Super<wbr>cali<wbr>fragilistic</p></article></body></html>`;


### PR DESCRIPTION
## Summary
- promote common lazy image source attributes when an image src is a data:image placeholder
- include data-original, data-lazy-src, data-actualsrc, and data-backup in lazy-image cleanup
- keep small placeholder images when they have an alternate lazy source so standardization can resolve them

Moved this fix here after maintainer feedback on obsidianmd/obsidian-clipper#896 that the change belongs in Defuddle.

## Tests
- git diff --check
- npm test
- npm run build
- npm run lint:innerhtml
- npm run size