### PR TITLE
fix: preserve substantive content sections with tags id

### DIFF
--- a/src/removals/selectors.ts
+++ b/src/removals/selectors.ts
@@ -12,6 +12,26 @@ import { DebugRemoval } from '../types';
 import { textPreview, logDebug } from '../utils';
 import { getClassName, hasResponsiveShowClass } from '../utils/dom';
 
+function hasSubstantiveTagsContent(el: Element): boolean {
+	if ((el.id || '').toLowerCase() !== 'tags') return false;
+	if (!el.querySelector('h1, h2, h3, h4, h5, h6')) return false;
+
+	const text = el.textContent?.trim() || '';
+	if (!text) return false;
+
+	const linkText = Array.from(el.querySelectorAll('a'))
+		.map(a => a.textContent || '')
+		.join(' ')
+		.trim();
+	if (linkText && linkText.length / text.length > 0.7) return false;
+
+	return Array.from(el.querySelectorAll('p')).some(p => {
+		const paragraph = p.textContent?.trim() || '';
+		const words = paragraph.split(/\s+/).filter(Boolean).length;
+		return words >= 2 && /[.!?。！？]/.test(paragraph);
+	});
+}
+
 export function removeBySelector(doc: Document, debug: boolean, removeExact: boolean = true, removePartial: boolean = true, mainContent?: Element | null, debugRemovals?: DebugRemoval[], skipHiddenExactSelectors: boolean = false) {
 	const startTime = Date.now();
 	let exactSelectorCount = 0;
@@ -41,6 +61,9 @@ export function removeBySelector(doc: Document, debug: boolean, removeExact: boo
 				}
 				// Skip elements with responsive show classes (e.g. "hidden sm:flex")
 				if (el.matches(HIDDEN_EXACT_SELECTOR) && hasResponsiveShowClass(getClassName(el))) {
+					return;
+				}
+				if (hasSubstantiveTagsContent(el)) {
 					return;
 				}
 				elementsToRemove.set(el, { type: 'exact' });

--- a/tests/issues-321-tags-section.test.ts
+++ b/tests/issues-321-tags-section.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from 'vitest';
+import { Defuddle } from '../src/node';
+import { parseDocument } from './helpers';
+
+const html = `
+<!DOCTYPE html>
+<html>
+<head><title>Tags section test</title></head>
+<body>
+	<article>
+		<h1>Article title</h1>
+		<h2>Intro heading</h2>
+		<p>Intro paragraph with enough text to be treated as content.</p>
+
+		<section id="tags">
+			<h2>Content heading</h2>
+			<p>Content paragraph that should remain in the extracted output.</p>
+		</section>
+
+		<footer id="tags">
+			<a href="/tags/alpha">alpha</a>
+			<a href="/tags/beta">beta</a>
+		</footer>
+	</article>
+</body>
+</html>
+`;
+
+describe('issue #321', () => {
+	test('keeps substantive content sections with id="tags"', async () => {
+		const result = await Defuddle(parseDocument(html, 'https://example.com/tags-section'), 'https://example.com/tags-section', {
+			separateMarkdown: true,
+		});
+
+		expect(result.contentMarkdown).toContain('## Intro heading');
+		expect(result.contentMarkdown).toContain('Intro paragraph with enough text');
+		expect(result.contentMarkdown).toContain('## Content heading');
+		expect(result.contentMarkdown).toContain('Content paragraph that should remain');
+		expect(result.contentMarkdown).not.toContain('/tags/alpha');
+		expect(result.contentMarkdown).not.toContain('/tags/beta');
+	});
+});


### PR DESCRIPTION
## Summary

- Preserve substantive content sections that use `id="tags"` when they contain a heading and prose.
- Keep removing ordinary tag-cloud blocks that are mostly links.
- Add a regression test for issue #321.

Closes #321.

## Verification

- `PATH=/Users/jing/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH /Users/jing/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pnpm exec vitest run tests/issues-321-tags-section.test.ts`
- `git diff --check`

Noted:

- `tsc --noEmit --project tsconfig.json` currently fails on an existing `src/fetch.ts` `ArrayBuffer | SharedArrayBuffer` type mismatch, unrelated to this selector/test change.
