### PR TITLE
fix:pass extractor constructor parameters to the base extractor

### DIFF
--- a/src/extractors/chatgpt.ts
+++ b/src/extractors/chatgpt.ts
@@ -8,8 +8,8 @@ export class ChatGPTExtractor extends ConversationExtractor {
 	private footnoteCounter: number;
 	private cachedMessages: ConversationMessage[] | null = null;
 
-	constructor(document: Document, url: string) {
-		super(document, url);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 		this.turns = document.querySelectorAll('[data-testid^="conversation-turn-"]');
 		this.footnotes = [];
 		this.footnoteCounter = 0;

--- a/src/extractors/claude.ts
+++ b/src/extractors/claude.ts
@@ -5,8 +5,8 @@ import { serializeHTML } from '../utils/dom';
 export class ClaudeExtractor extends ConversationExtractor {
 	private articles: NodeListOf<Element> | null;
 
-	constructor(document: Document, url: string) {
-		super(document, url);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 		// Find all message blocks - both user and assistant messages
 		this.articles = document.querySelectorAll('div[data-testid="user-message"], div[data-testid="assistant-message"], div.font-claude-response');
 	}

--- a/src/extractors/gemini.ts
+++ b/src/extractors/gemini.ts
@@ -7,8 +7,8 @@ export class GeminiExtractor extends ConversationExtractor {
 	private footnotes: Footnote[];
 	private messageCount: number | null = null;
 
-	constructor(document: Document, url: string) {
-		super(document, url);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 		this.conversationContainers = document.querySelectorAll('div.conversation-container');
 		this.footnotes = [];
 	}

--- a/src/extractors/github.ts
+++ b/src/extractors/github.ts
@@ -7,8 +7,8 @@ export class GitHubExtractor extends BaseExtractor {
 	private isIssue: boolean;
 	private isPR: boolean;
 
-	constructor(document: Document, url: string) {
-		super(document, url);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 		this.isIssue = /\/issues\/\d+/.test(url);
 		this.isPR = /\/pull\/\d+/.test(url);
 	}

--- a/src/extractors/grok.ts
+++ b/src/extractors/grok.ts
@@ -9,8 +9,8 @@ export class GrokExtractor extends ConversationExtractor {
 	private footnotes: Footnote[];
 	private footnoteCounter: number;
 
-	constructor(document: Document, url: string) {
-		super(document, url);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 		this.messageBubbles = document.querySelectorAll(this.messageContainerSelector);
 		this.footnotes = [];
 		this.footnoteCounter = 0;

--- a/src/extractors/hackernews.ts
+++ b/src/extractors/hackernews.ts
@@ -21,8 +21,8 @@ export class HackerNewsExtractor extends BaseExtractor {
 	private isListingPage: boolean;
 	private mainComment: Element | null;
 
-	constructor(document: Document, url: string) {
-		super(document, url);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 		this.mainPost = document.querySelector('.fatitem');
 		this.isListingPage = this.detectListingPage();
 		this.isCommentPage = this.detectCommentPage();

--- a/src/extractors/reddit.ts
+++ b/src/extractors/reddit.ts
@@ -7,8 +7,8 @@ export class RedditExtractor extends BaseExtractor {
 	private shredditPost: Element | null;
 	private isOldReddit: boolean;
 
-	constructor(document: Document, url: string) {
-		super(document, url);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 		this.shredditPost = document.querySelector('shreddit-post');
 		this.isOldReddit = !!document.querySelector('.thing.link');
 	}

--- a/src/extractors/twitter.ts
+++ b/src/extractors/twitter.ts
@@ -9,8 +9,8 @@ export class TwitterExtractor extends BaseExtractor {
 	private replyTweets: Element[] = [];
 	private replyDepths: number[] = [];
 
-	constructor(document: Document, url: string) {
-		super(document, url);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 
 		// Get all tweets from the timeline
 		const timeline = Array.from(document.querySelectorAll('[aria-label]'))

--- a/src/extractors/x-article.ts
+++ b/src/extractors/x-article.ts
@@ -23,8 +23,8 @@ const SELECTORS = {
 export class XArticleExtractor extends BaseExtractor {
 	private articleContainer: Element | null;
 
-	constructor(document: Document, url: string, schemaOrgData?: any) {
-		super(document, url, schemaOrgData);
+	constructor(document: Document, url: string, schemaOrgData?: any, options?: any) {
+		super(document, url, schemaOrgData, options);
 		this.articleContainer = document.querySelector(SELECTORS.ARTICLE_CONTAINER);
 	}
 


### PR DESCRIPTION
Fixes #323 and would probably fix similar problems with other extractors.

Looks like it was just a minor compatibility issue. I found it when I was testing the cli against reddit and it broke with 403 despite me passing a customized `fetch` to the options object.

I mirrored how things were wired up in other extractor, built the project after my changes and tested it with reddit locally, everything works now. But I didn't test other extractors that I changed. Looking at the code and their constructor chains they are probably ok. @kepano FYI.