### PR TITLE
Add Perplexity conversation extractor

### DIFF
--- a/src/extractor-registry.ts
+++ b/src/extractor-registry.ts
@@ -11,6 +11,7 @@ import { ChatGPTExtractor } from './extractors/chatgpt';
 import { ClaudeExtractor } from './extractors/claude';
 import { GrokExtractor } from './extractors/grok';
 import { GeminiExtractor } from './extractors/gemini';
+import { PerplexityExtractor } from './extractors/perplexity';
 import { GitHubExtractor } from './extractors/github';
 import { XOembedExtractor } from './extractors/x-oembed';
 import { BbcodeDataExtractor } from './extractors/bbcode-data';
@@ -127,6 +128,13 @@ export class ExtractorRegistry {
 				/^https?:\/\/gemini\.google\.com\/app\/.*/
 			],
 			extractor: GeminiExtractor
+		});
+
+		this.register({
+			patterns: [
+				/^https?:\/\/(?:www\.)?perplexity\.ai\/search\/.*/
+			],
+			extractor: PerplexityExtractor
 		});
 
 		this.register({

--- a/src/extractors/perplexity.ts
+++ b/src/extractors/perplexity.ts
@@ -1,0 +1,243 @@
+import { ConversationExtractor } from './_conversation';
+import { ConversationMessage, ConversationMetadata, Footnote } from '../types/extractors';
+import { escapeHtml, serializeHTML } from '../utils/dom';
+
+const USER_MESSAGE_SELECTOR = 'span.select-text';
+const ANSWER_SELECTOR = '[id^="markdown-content-"]';
+const ANSWER_CONTENT_SELECTOR = '[data-renderer="lm"]';
+const CITATION_SELECTOR = '[data-pplx-citation-url]';
+const PREPARED_BY_PATTERN = /^Prepared by .+\bThinking$/i;
+
+export class PerplexityExtractor extends ConversationExtractor {
+	private answerBlocks: NodeListOf<Element>;
+	private cachedMessages: ConversationMessage[] | null = null;
+	private footnotes: Footnote[] = [];
+	private footnoteIndexes = new Map<string, number>();
+	private footnoteReferenceCounts = new Map<number, number>();
+
+	constructor(document: Document, url: string) {
+		super(document, url);
+		this.answerBlocks = document.querySelectorAll(ANSWER_SELECTOR);
+	}
+
+	canExtract(): boolean {
+		return Array.from(this.answerBlocks).some(answerBlock =>
+			this.getAnswerContentElements(answerBlock).some(element =>
+				Boolean(
+					element.textContent?.trim() ||
+					element.querySelector('img, pre, table, math')
+				)
+			)
+		);
+	}
+
+	protected extractMessages(): ConversationMessage[] {
+		if (this.cachedMessages) return this.cachedMessages;
+
+		this.footnotes = [];
+		this.footnoteIndexes.clear();
+		this.footnoteReferenceCounts.clear();
+
+		const messages: ConversationMessage[] = [];
+		const userMessageElements = new Set(
+			Array.from(this.answerBlocks)
+				.map(answerBlock => this.getUserMessageElement(answerBlock))
+				.filter((element): element is Element => Boolean(element))
+		);
+		const messageElements = this.document.querySelectorAll(
+			`${USER_MESSAGE_SELECTOR}, ${ANSWER_SELECTOR}`
+		);
+
+		messageElements.forEach(element => {
+			if (element.matches(USER_MESSAGE_SELECTOR)) {
+				if (!userMessageElements.has(element)) return;
+
+				const content = serializeHTML(element).trim();
+				if (content) {
+					messages.push({
+						author: 'You',
+						content,
+						metadata: { role: 'user' },
+					});
+				}
+				return;
+			}
+
+			if (!element.matches(ANSWER_SELECTOR)) return;
+
+			const content = this.extractAnswerContent(element);
+			if (content) {
+				messages.push({
+					author: 'Perplexity',
+					content,
+					metadata: { role: 'assistant' },
+				});
+			}
+		});
+
+		this.cachedMessages = messages;
+		return messages;
+	}
+
+	private getUserMessageElement(answerBlock: Element): Element | null {
+		for (
+			let container = answerBlock.parentElement;
+			container && container !== this.document.body;
+			container = container.parentElement
+		) {
+			const userMessages = container.querySelectorAll(USER_MESSAGE_SELECTOR);
+			const answers = container.querySelectorAll(ANSWER_SELECTOR);
+
+			if (userMessages.length === 1 && answers.length === 1) {
+				return userMessages[0];
+			}
+
+			if (answers.length > 1) break;
+		}
+
+		return null;
+	}
+
+	protected getFootnotes(): Footnote[] {
+		return this.footnotes;
+	}
+
+	protected getMetadata(): ConversationMetadata {
+		const messages = this.extractMessages();
+		return {
+			title: this.getTitle(messages),
+			site: 'Perplexity',
+			url: this.url,
+			messageCount: messages.length,
+			description: `Perplexity conversation with ${messages.length} messages`,
+		};
+	}
+
+	private extractAnswerContent(answerBlock: Element): string {
+		return this.getAnswerContentElements(answerBlock)
+			.map(element => {
+				const clone = element.cloneNode(true) as Element;
+				this.removeNoise(clone);
+				this.processCitations(clone);
+				return serializeHTML(clone).trim();
+			})
+			.filter(Boolean)
+			.join('\n');
+	}
+
+	private getAnswerContentElements(answerBlock: Element): Element[] {
+		const candidates = [
+			...(answerBlock.matches(ANSWER_CONTENT_SELECTOR) ? [answerBlock] : []),
+			...Array.from(answerBlock.querySelectorAll(ANSWER_CONTENT_SELECTOR))
+				.filter(candidate => candidate.closest(ANSWER_SELECTOR) === answerBlock),
+		];
+
+		// Keep outermost renderer nodes so nested wrappers are not serialized twice.
+		return candidates.filter(candidate =>
+			!candidates.some(other => other !== candidate && other.contains(candidate))
+		);
+	}
+
+	private removeNoise(root: Element): void {
+		root.querySelectorAll(
+			'[data-saveai-injected], [data-ask-input-container], #ask-input, button, [role="button"]'
+		).forEach(element => element.remove());
+
+		root.querySelectorAll('.citation-nbsp').forEach(element => {
+			element.replaceWith(this.document.createTextNode(' '));
+		});
+
+		const preparedByElements = Array.from(root.querySelectorAll('*'))
+			.filter(element => PREPARED_BY_PATTERN.test(element.textContent?.trim() || ''))
+			.filter(element =>
+				!Array.from(element.children).some(child =>
+					PREPARED_BY_PATTERN.test(child.textContent?.trim() || '')
+				)
+			);
+
+		preparedByElements.forEach(element => element.remove());
+	}
+
+	private processCitations(root: Element): void {
+		root.querySelectorAll(CITATION_SELECTOR).forEach(citation => {
+			const rawUrl = citation.getAttribute('data-pplx-citation-url')?.trim() || '';
+			const url = this.getHttpUrl(rawUrl);
+			if (!url) {
+				citation.replaceWith(...Array.from(citation.childNodes));
+				return;
+			}
+
+			let footnoteIndex = this.footnoteIndexes.get(url);
+			if (!footnoteIndex) {
+				footnoteIndex = this.footnotes.length + 1;
+				this.footnoteIndexes.set(url, footnoteIndex);
+				this.footnotes.push({
+					url,
+					text: this.getCitationLabel(citation, url),
+				});
+			}
+
+			const referenceCount = (this.footnoteReferenceCounts.get(footnoteIndex) || 0) + 1;
+			this.footnoteReferenceCounts.set(footnoteIndex, referenceCount);
+
+			const reference = this.document.createElement('sup');
+			reference.id = referenceCount === 1
+				? `fnref:${footnoteIndex}`
+				: `fnref:${footnoteIndex}-${referenceCount}`;
+			reference.className = 'footnote-ref';
+
+			const link = this.document.createElement('a');
+			link.setAttribute('href', `#fn:${footnoteIndex}`);
+			link.className = 'footnote-link';
+			link.textContent = footnoteIndex.toString();
+
+			reference.appendChild(link);
+			citation.replaceWith(reference);
+		});
+	}
+
+	private getCitationLabel(citation: Element, url: string): string {
+		const visibleText = (citation.textContent || '')
+			.replace(/\+\d+\s*$/, '')
+			.trim();
+		if (visibleText) return escapeHtml(visibleText);
+
+		try {
+			return escapeHtml(new URL(url).hostname.replace(/^www\./, ''));
+		} catch {
+			return escapeHtml(url);
+		}
+	}
+
+	private getHttpUrl(url: string): string | null {
+		try {
+			const parsed = new URL(url, this.url);
+			return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+				? parsed.href
+				: null;
+		} catch {
+			return null;
+		}
+	}
+
+	private getTitle(messages: ConversationMessage[]): string {
+		const pageTitle = this.document.title?.trim() || '';
+		const cleanedTitle = pageTitle
+			.replace(/\s*[-|]\s*Perplexity(?: AI)?$/i, '')
+			.trim();
+		if (cleanedTitle && !/^Perplexity(?: AI)?$/i.test(cleanedTitle)) {
+			return cleanedTitle;
+		}
+
+		const firstUserMessage = messages.find(message => message.metadata?.role === 'user');
+		const text = firstUserMessage?.content
+			.replace(/<[^>]+>/g, ' ')
+			.replace(/\s+/g, ' ')
+			.trim() || '';
+		if (text) {
+			return text.length > 80 ? `${text.slice(0, 80)}...` : text;
+		}
+
+		return 'Perplexity Conversation';
+	}
+}

--- a/tests/expected/extractor--perplexity-conversation.md
+++ b/tests/expected/extractor--perplexity-conversation.md
@@ -1,0 +1,44 @@
+```json
+{
+  "title": "Build a streaming parser",
+  "author": "",
+  "site": "Perplexity",
+  "published": ""
+}
+```
+
+**You**
+
+How should I parse streamed Markdown?
+
+---
+
+**Perplexity**
+
+Start with an incremental parser. [^1]
+
+## Checklist
+
+- Preserve incomplete tokens
+- Render stable blocks
+```
+parser.write(chunk);
+```
+
+---
+
+**You**
+
+How do I keep citations?
+
+---
+
+**Perplexity**
+
+Convert citation pills to footnotes [^1] and keep distinct sources [^2].
+
+An invalid citation keeps its visible label: Unsafe label.
+
+[^1]: [Example Docs](https://example.com/parser)
+
+[^2]: [Spec & Guide](https://example.org/spec)

--- a/tests/extractor-xss.test.ts
+++ b/tests/extractor-xss.test.ts
@@ -9,6 +9,7 @@ import { parseLinkedomHTML } from '../src/utils/linkedom-compat';
 // close the attribute and inject an event handler or a javascript: URL.
 
 const X_URL = 'https://x.com/testuser/article/123456789';
+const PERPLEXITY_URL = 'https://www.perplexity.ai/search/xss-test';
 
 // Header image lives in the read view but OUTSIDE the article container, so
 // extractHeaderImage() emits it via a template string.
@@ -57,6 +58,33 @@ describe('Extractor output XSS sanitization (GHSA-jg4p-g6xj-4qmf)', () => {
 		const html = makeXArticleHTML('src="javascript:alert(1)" alt="ok"');
 		const doc = parseLinkedomHTML(html, X_URL);
 		const response = await Defuddle(doc, X_URL);
+
+		assertNoExecutableAttributes(response.content);
+	});
+
+	test('does not emit executable attributes from Perplexity answer content or citations', async () => {
+		const html = `
+			<html><head><title>Perplexity XSS test</title></head>
+			<body>
+				<section>
+					<span class="select-text">Summarize the source</span>
+					<div id="markdown-content-0">
+						<div data-renderer="lm">
+							<p>
+								Answer
+								<span
+									data-pplx-citation-url='https://example.com/%22%20onclick=%22alert(1)'
+								>Source " onclick="alert(1)</span>
+							</p>
+							<img src="javascript:alert(1)" onerror="alert(1)" alt="unsafe">
+							<a href="javascript:alert(1)" onclick="alert(1)">Unsafe link</a>
+						</div>
+					</div>
+				</section>
+			</body></html>
+		`;
+		const doc = parseLinkedomHTML(html, PERPLEXITY_URL);
+		const response = await Defuddle(doc, PERPLEXITY_URL);
 
 		assertNoExecutableAttributes(response.content);
 	});

--- a/tests/fixtures/extractor--perplexity-conversation.html
+++ b/tests/fixtures/extractor--perplexity-conversation.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<!-- {"url":"https://www.perplexity.ai/search/test-conversation"} -->
+<html>
+<head>
+	<title>Build a streaming parser - Perplexity</title>
+</head>
+<body>
+	<main>
+		<section>
+			<div role="heading">
+				<span class="select-text">How should I parse streamed Markdown?</span>
+			</div>
+			<div id="markdown-content-0">
+				<div data-renderer="lm">
+					<p>Start with an incremental parser.<span class="citation-nbsp"></span>
+						<span data-pplx-citation-url="https://example.com/parser">
+							<span>Example Docs</span><span>+2</span>
+						</span>
+					</p>
+					<h2>Checklist</h2>
+					<ul>
+						<li>Preserve incomplete tokens</li>
+						<li>Render stable blocks</li>
+					</ul>
+					<pre><code>parser.write(chunk);</code></pre>
+					<div data-saveai-injected="true">Injected extension control</div>
+					<button>Copy answer</button>
+					<div><span>Prepared by GPT-5.4 Thinking</span></div>
+				</div>
+			</div>
+		</section>
+		<section>
+			<div>
+				<span class="select-text">How do I keep citations?</span>
+			</div>
+			<div id="markdown-content-1">
+				<div data-renderer="lm">
+					<p>Convert citation pills to footnotes
+						<span data-pplx-citation-url="https://example.com/parser">
+							<span>Example Docs</span>
+						</span>
+						and keep distinct sources
+						<span data-pplx-citation-url="https://example.org/spec">
+							<span>Spec &amp; Guide</span>
+						</span>.
+					</p>
+					<p>An invalid citation keeps its visible label:
+						<span data-pplx-citation-url="javascript:alert(1)">Unsafe label</span>.
+					</p>
+				</div>
+			</div>
+		</section>
+		<aside><span class="select-text">Unrelated selectable sidebar text</span></aside>
+		<div class="follow-up">Follow-up prompt</div>
+		<div data-ask-input-container="true">
+			<div id="ask-input">Search input</div>
+			<span>Search</span><span>Computer</span><span>Model</span>
+		</div>
+	</main>
+</body>
+</html>

--- a/tests/perplexity-extractor.test.ts
+++ b/tests/perplexity-extractor.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import Defuddle from '../src/index.full';
+import { PerplexityExtractor } from '../src/extractors/perplexity';
+import { parseDocument } from './helpers';
+
+const PERPLEXITY_URL = 'https://www.perplexity.ai/search/test-conversation';
+const conversationHTML = readFileSync(
+	join(__dirname, 'fixtures', 'extractor--perplexity-conversation.html'),
+	'utf-8'
+);
+
+describe('PerplexityExtractor', () => {
+	test('extracts conversation turns in order and preserves rich answer content', () => {
+		const doc = parseDocument(conversationHTML, PERPLEXITY_URL);
+		const result = new Defuddle(doc, {
+			url: PERPLEXITY_URL,
+			separateMarkdown: true,
+		}).parse();
+		const markdown = result.contentMarkdown || '';
+
+		expect(result.extractorType).toBe('perplexity');
+		expect(result.title).toBe('Build a streaming parser');
+		expect(result.site).toBe('Perplexity');
+
+		const orderedContent = [
+			'How should I parse streamed Markdown?',
+			'Start with an incremental parser.',
+			'How do I keep citations?',
+			'Convert citation pills to footnotes',
+		];
+		let previousIndex = -1;
+		for (const content of orderedContent) {
+			const currentIndex = markdown.indexOf(content);
+			expect(currentIndex).toBeGreaterThan(previousIndex);
+			previousIndex = currentIndex;
+		}
+
+		expect(markdown).toContain('## Checklist');
+		expect(markdown).toContain('- Preserve incomplete tokens');
+		expect(markdown).toContain('parser.write(chunk);');
+		expect(markdown).not.toContain('Injected extension control');
+		expect(markdown).not.toContain('Copy answer');
+		expect(markdown).not.toContain('Prepared by GPT-5.4 Thinking');
+		expect(markdown).not.toContain('Unrelated selectable sidebar text');
+		expect(markdown).not.toContain('Follow-up prompt');
+		expect(markdown).not.toContain('Search input');
+		expect(markdown).not.toContain('Computer');
+		expect(markdown).not.toContain('Model');
+	});
+
+	test('converts citations to deduplicated Markdown footnotes', () => {
+		const doc = parseDocument(conversationHTML, PERPLEXITY_URL);
+		const result = new Defuddle(doc, {
+			url: PERPLEXITY_URL,
+			separateMarkdown: true,
+		}).parse();
+		const markdown = result.contentMarkdown || '';
+
+		expect(markdown.match(/\[\^1\]/g)).toHaveLength(3);
+		expect(markdown.match(/\[\^1\]:/g)).toHaveLength(1);
+		expect(markdown.match(/\[\^2\]:/g)).toHaveLength(1);
+		expect(markdown).toContain('[Example Docs](https://example.com/parser)');
+		expect(markdown).toContain('[Spec & Guide](https://example.org/spec)');
+		expect(markdown).toContain('Unsafe label');
+		expect(markdown).not.toContain('javascript:alert(1)');
+
+		const html = result.content;
+		expect(html).toContain('id="fnref:1"');
+		expect(html).toContain('id="fnref:1-2"');
+	});
+
+	test('does not claim empty or non-answer Perplexity pages', () => {
+		const emptyDoc = parseDocument(`
+			<html><body>
+				<div role="heading"><span class="select-text">A draft query</span></div>
+				<div id="markdown-content-0"><div class="loading">Loading</div></div>
+			</body></html>
+		`, 'https://www.perplexity.ai/');
+
+		expect(new PerplexityExtractor(emptyDoc, 'https://www.perplexity.ai/').canExtract()).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- add a Perplexity-specific conversation extractor
- preserve ordered user and assistant turns, rich Markdown, and deduplicated citation footnotes
- remove Perplexity-specific controls and answer noise
- reject unsafe citation URL schemes and cover extractor output sanitization
- add a synthetic multi-turn fixture and focused extractor tests

## Testing

- `npm test` (404 tests)
- `npm run build`
- `npm run size`
- `npm run lint:innerhtml`
- `git diff --check`
- manual Arc verification on single-turn and multi-turn Perplexity conversations

Fixes #338