### PR TITLE
fix: retry forbidden page fetches with a browser user agent

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { resolve } from 'path';
 import { parseLinkedomHTML } from './utils/linkedom-compat';
 import { countWords } from './utils';
 import { buildFrontmatter } from './frontmatter';
-import { getInitialUA, fetchPage, extractRawMarkdown, cleanMarkdownContent, BOT_UA } from './fetch';
+import { getInitialUA, fetchPage, fetchPageWithRetry, extractRawMarkdown, cleanMarkdownContent, BOT_UA } from './fetch';
 
 export interface ParseOptions {
 	output?: string;
@@ -74,7 +74,9 @@ export async function parseSource(source: string | undefined, options: ParseOpti
 	} else if (isUrl) {
 		url = source;
 		const initialUA = options.userAgent || getInitialUA(source);
-		html = await fetchPage(source, initialUA, options.lang);
+		html = options.userAgent
+			? await fetchPage(source, initialUA, options.lang)
+			: await fetchPageWithRetry(source, initialUA, options.lang);
 	} else {
 		const filePath = resolve(process.cwd(), source);
 		html = await readFile(filePath, 'utf-8');

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -6,6 +6,7 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 export const DEFAULT_UA = 'Mozilla/5.0 (compatible; Defuddle/1.0; +https://defuddle.md)';
 export const BOT_UA = DEFAULT_UA + ' bot';
+export const BROWSER_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
 
 // Domains that serve better content to bot user agents (e.g. SSR vs client-rendered)
 export const BOT_UA_DOMAINS = ['github.com'];
@@ -57,6 +58,12 @@ function validateAndDecode(contentType: string, contentLength: string | null | u
 		throw new Error(`Page too large (${Math.round(buffer.byteLength / 1024 / 1024)}MB, max 5MB)`);
 	}
 	return decodeHtml(buffer, contentType);
+}
+
+class HttpError extends Error {
+	constructor(readonly status: number, message: string) {
+		super(message);
+	}
 }
 
 // Raw HTTP(S) GET through a proxy, returning status + headers + body buffer.
@@ -180,7 +187,7 @@ async function fetchPageViaProxy(
 	}
 
 	if (status < 200 || status >= 300) {
-		throw new Error(`Failed to fetch: ${status}`);
+		throw new HttpError(status, `Failed to fetch: ${status}`);
 	}
 	const contentType = (resHeaders['content-type'] as string) || '';
 	const contentLength = resHeaders['content-length'] as string | undefined;
@@ -213,7 +220,7 @@ export async function fetchPage(targetUrl: string, userAgent: string, language?:
 		});
 
 		if (!response.ok) {
-			throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+			throw new HttpError(response.status, `Failed to fetch: ${response.status} ${response.statusText}`);
 		}
 
 		const contentType = response.headers.get('content-type') || '';
@@ -237,6 +244,17 @@ export async function fetchPage(targetUrl: string, userAgent: string, language?:
 		throw err;
 	} finally {
 		clearTimeout(timer);
+	}
+}
+
+export async function fetchPageWithRetry(targetUrl: string, userAgent: string, language?: string): Promise<string> {
+	try {
+		return await fetchPage(targetUrl, userAgent, language);
+	} catch (error) {
+		if (!(error instanceof HttpError) || error.status !== 403 || userAgent === BROWSER_UA) {
+			throw error;
+		}
+		return fetchPage(targetUrl, BROWSER_UA, language);
 	}
 }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { readFileSync, rmSync, writeFileSync, mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -6,6 +6,7 @@ import { Readable } from 'stream';
 import { Defuddle } from '../src/node';
 import { parseSource, createProgram } from '../src/cli';
 import { parseDocument } from './helpers';
+import { BROWSER_UA } from '../src/fetch';
 
 const fixturePath = join(__dirname, 'fixtures', 'general--appendix-heading.html');
 const fixtureHtml = readFileSync(fixturePath, 'utf-8');
@@ -105,4 +106,58 @@ describe('CLI parseSource', () => {
 		// commander camelCases --user-agent → options.userAgent, which parseSource reads.
 		expect(option?.attributeName()).toBe('userAgent');
 	});
+
+	test('retries a 403 with a browser user agent', async () => {
+		const buffer = new TextEncoder().encode(fixtureHtml).buffer;
+		const fetchMock = vi.fn()
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 403,
+				statusText: 'Forbidden',
+				headers: { get: () => null },
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: 'OK',
+				headers: { get: (header: string) => header === 'content-type' ? 'text/html' : null },
+				arrayBuffer: () => Promise.resolve(buffer),
+			});
+		vi.stubGlobal('fetch', fetchMock);
+		for (const name of ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy']) {
+			vi.stubEnv(name, undefined as any);
+		}
+
+		const result = await parseSource('https://example.com', {});
+
+		expect(result.output).toContain('Appendix I');
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock.mock.calls[1][1].headers['User-Agent']).toBe(BROWSER_UA);
+	});
+
+	test('does not replace an explicitly supplied user agent after a 403', async () => {
+		const customUserAgent = 'custom-agent';
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 403,
+			statusText: 'Forbidden',
+			headers: { get: () => null },
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		for (const name of ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy']) {
+			vi.stubEnv(name, undefined as any);
+		}
+
+		await expect(parseSource('https://example.com', { userAgent: customUserAgent })).rejects.toThrow(
+			'Failed to fetch: 403 Forbidden'
+		);
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(fetchMock.mock.calls[0][1].headers['User-Agent']).toBe(customUserAgent);
+		expect(fetchMock.mock.calls[0][1].headers['User-Agent']).not.toBe(BROWSER_UA);
+	});
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.unstubAllEnvs();
 });

--- a/tests/fetch.test.ts
+++ b/tests/fetch.test.ts
@@ -1,15 +1,32 @@
 import { describe, test, expect, vi, afterEach, beforeEach } from 'vitest';
-import { fetchPage, DEFAULT_UA } from '../src/fetch';
+import { fetchPage, fetchPageWithRetry, BROWSER_UA, DEFAULT_UA } from '../src/fetch';
 
 const HTML = '<html><head></head><body>hello</body></html>';
 
-function mockFetch(contentType: string) {
-	const buffer = new TextEncoder().encode(HTML).buffer;
-	vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-		ok: true,
-		headers: { get: (h: string) => h === 'content-type' ? contentType : null },
+function response(status: number, options: { contentType?: string; contentLength?: string; html?: string } = {}) {
+	const {
+		contentType = 'text/html',
+		contentLength,
+		html = HTML,
+	} = options;
+	const buffer = new TextEncoder().encode(html).buffer;
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: status === 403 ? 'Forbidden' : status === 500 ? 'Internal Server Error' : 'OK',
+		headers: {
+			get: (header: string) => {
+				if (header === 'content-type') return contentType;
+				if (header === 'content-length') return contentLength || null;
+				return null;
+			},
+		},
 		arrayBuffer: () => Promise.resolve(buffer),
-	}));
+	};
+}
+
+function mockFetch(contentType: string) {
+	vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response(200, { contentType })));
 }
 
 beforeEach(() => {
@@ -36,5 +53,87 @@ describe('fetchPage charset handling', () => {
 	test('handles quoted charset (charset="utf-8")', async () => {
 		mockFetch('text/html; charset="utf-8"');
 		await expect(fetchPage('https://example.com', DEFAULT_UA)).resolves.toContain('hello');
+	});
+});
+
+describe('fetchPageWithRetry', () => {
+	test('retries a 403 once with a browser user agent and preserves language', async () => {
+		const fetchMock = vi.fn()
+			.mockResolvedValueOnce(response(403))
+			.mockResolvedValueOnce(response(200));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(fetchPageWithRetry('https://example.com', DEFAULT_UA, 'fr')).resolves.toContain('hello');
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock.mock.calls[0][1].headers).toMatchObject({
+			'User-Agent': DEFAULT_UA,
+			'Accept-Language': 'fr',
+		});
+		expect(fetchMock.mock.calls[1][1].headers).toMatchObject({
+			'User-Agent': BROWSER_UA,
+			'Accept-Language': 'fr',
+		});
+	});
+
+	test('does not retry a successful response', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response(200));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(fetchPageWithRetry('https://example.com', DEFAULT_UA)).resolves.toContain('hello');
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	test('rejects after one browser user agent retry', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response(403));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(fetchPageWithRetry('https://example.com', DEFAULT_UA)).rejects.toThrow(
+			'Failed to fetch: 403 Forbidden'
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('does not retry unrelated HTTP failures', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response(500));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(fetchPageWithRetry('https://example.com', DEFAULT_UA)).rejects.toThrow(
+			'Failed to fetch: 500 Internal Server Error'
+		);
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	test('does not retry timeouts', async () => {
+		const timeoutError = new Error('aborted');
+		timeoutError.name = 'AbortError';
+		const fetchMock = vi.fn().mockRejectedValue(timeoutError);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(fetchPageWithRetry('https://example.com', DEFAULT_UA)).rejects.toThrow(
+			'Timed out fetching page after 10s'
+		);
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	test('does not retry invalid content types', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response(200, { contentType: 'application/json' }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(fetchPageWithRetry('https://example.com', DEFAULT_UA)).rejects.toThrow(
+			'Not an HTML page (content-type: application/json)'
+		);
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	test('does not retry oversized responses', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response(200, { contentLength: String(6 * 1024 * 1024) }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(fetchPageWithRetry('https://example.com', DEFAULT_UA)).rejects.toThrow(
+			'Page too large (6MB, max 5MB)'
+		);
+		expect(fetchMock).toHaveBeenCalledOnce();
 	});
 });

--- a/website/src/convert.ts
+++ b/website/src/convert.ts
@@ -3,7 +3,7 @@ import { Defuddle } from '../../src/defuddle';
 import { toMarkdown } from '../../src/markdown';
 import { countWords } from '../../src/utils';
 import { buildFrontmatter } from '../../src/frontmatter';
-import { getInitialUA, fetchPage, extractRawMarkdown, cleanMarkdownContent, BOT_UA, DEFAULT_UA, FETCH_TIMEOUT } from '../../src/fetch';
+import { getInitialUA, fetchPage, fetchPageWithRetry, extractRawMarkdown, cleanMarkdownContent, BOT_UA, DEFAULT_UA, FETCH_TIMEOUT } from '../../src/fetch';
 import type { DefuddleOptions, DefuddleResponse } from '../../src/types';
 
 function createDefuddle(html: string, targetUrl: string, opts?: Partial<DefuddleOptions>) {
@@ -135,7 +135,7 @@ export async function convertToHtml(targetUrl: string, language?: string): Promi
 	}
 
 	const initialUA = getInitialUA(targetUrl);
-	const html = await fetchPage(targetUrl, initialUA, language);
+	const html = await fetchPageWithRetry(targetUrl, initialUA, language);
 	let result = await defuddleHtmlAsync(html, targetUrl, language);
 
 	if (result.wordCount === 0 && initialUA !== BOT_UA) {
@@ -167,7 +167,7 @@ export async function convertToMarkdown(targetUrl: string, language?: string): P
 	}
 
 	const initialUA = getInitialUA(targetUrl);
-	const html = await fetchPage(targetUrl, initialUA, language);
+	const html = await fetchPageWithRetry(targetUrl, initialUA, language);
 	let result = await defuddleHtmlAsync(html, targetUrl, language);
 
 	// If no content was extracted, the page may be JS-rendered.


### PR DESCRIPTION
Add a shared, single-retry fetch policy in `src/fetch.ts` that retries a 403 response with a browser-compatible user agent while preserving the existing timeout, proxy, redirect, size, content-type, and language behavior for each attempt. The current shared fetch path identifies itself with the Defuddle user agent, and AccuWeather responds to that request with `403 Forbidden` before parsing begins.

A built-in Defuddle user-agent request receives 403, the browser-user-agent retry receives valid HTML, and the caller receives that HTML for parsing; A first-attempt success makes only one request; language headers survive the retry; and a CLI invocation with an explicit custom user agent never substitutes the browser fallback.

Closes #348
