### PR TITLE
Fix nested list indentation

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -260,11 +260,19 @@ export function createMarkdownContent(content: string, url: string) {
 		replacement: function (content: string, node: Node) {
 			// Remove trailing newlines/spaces from content
 			content = content.trim();
-			
-			// Add a newline before the list if it's a top-level list
+
 			const element = node as unknown as GenericElement;
-			const isTopLevel = !(element.parentNode && (element.parentNode.nodeName === 'UL' || element.parentNode.nodeName === 'OL'));
-			return (isTopLevel ? '\n' : '') + content + '\n';
+			const parent = element.parentNode;
+			// A ul/ol directly inside another ul/ol(not in <li>)
+			const isMalformedNestedInList = !!parent && (parent.nodeName === 'UL' || parent.nodeName === 'OL');
+
+			if (isMalformedNestedInList) {
+				// Tab indentation for malformed markup
+				return content.split('\n').map(line => line && '\t' + line).join('\n') + '\n';
+			}
+
+			// Add a newline before the list if it's a top-level list
+			return '\n' + content + '\n';
 		}
 	});
 

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -298,22 +298,6 @@ export function createMarkdownContent(content: string, url: string) {
 			let prefix = options.bulletListMarker + ' ';
 			let parent = node.parentNode;
 
-			// Calculate the nesting level
-			let level = 0;
-			let currentParent = node.parentNode;
-			while (currentParent && isGenericElement(currentParent)) {
-				if (currentParent.nodeName === 'UL' || currentParent.nodeName === 'OL') {
-					level++;
-				} else if (currentParent.nodeName !== 'LI') {
-					break;
-				}
-				currentParent = currentParent.parentNode;
-			}
-
-			// Add tab indentation based on nesting level, ensuring it's never negative
-			const indentLevel = Math.max(0, level - 1);
-			prefix = '\t'.repeat(indentLevel) + prefix;
-
 			if (parent && isGenericElement(parent) && parent.nodeName === 'OL') {
 				let start = parent.getAttribute('start');
 				let index = 1;
@@ -324,7 +308,7 @@ export function createMarkdownContent(content: string, url: string) {
 						break;
 					}
 				}
-				prefix = '\t'.repeat(level - 1) + (start ? Number(start) + index - 1 : index) + '. ';
+				prefix = (start ? Number(start) + index - 1 : index) + '. ';
 			}
 
 			return prefix + taskListMarker + content.trim() + (node.nextSibling && !/\n$/.test(content) ? '\n' : '');

--- a/tests/expected/general--lesswrong.com-s-N7nDePaNabJdnbXeE-p-vJFdjigzmcXMhNTsx.md
+++ b/tests/expected/general--lesswrong.com-s-N7nDePaNabJdnbXeE-p-vJFdjigzmcXMhNTsx.md
@@ -498,21 +498,21 @@ The next couple of posts (if I finish them before the end of the world) will pre
 	- **Conditioning.** GPT can be controlled to an impressive extent by prompt programming. Conditioning preserves distributional properties in potentially desirable but also potentially undesirable ways, and it’s not clear how out-of-distribution conditions will be interpreted by powerful simulators.
 		- Several posts have been made about this recently:
 			- [Conditioning Generative Models](https://lesswrong.com/posts/nXeLPcT9uhfG3TMPS/conditioning-generative-models).) and [Conditioning Generative Models with Restrictions](https://lesswrong.com/posts/adiszfnFgPEnRsGSr/conditioning-generative-models-with-restrictions) by Adam Jermyn
-						- [Conditioning Generative Models for Alignment](https://lesswrong.com/posts/JqnkeqaPseTgxLgEL/conditioning-generative-models-for-alignment) by Jozdien
-						- [Training goals for large language models](https://lesswrong.com/posts/dWJNFHnC4bkdbovug/training-goals-for-large-language-models) by Johannes Treutlein
-						- [Strategy For Conditioning Generative Models](https://lesswrong.com/posts/HAz7apopTzozrqW2k/strategy-for-conditioning-generative-models) by James Lucassen and Evan Hubinger
-				- Instead of conditioning on a prompt ("observable" variables), we might also control generative models by [conditioning on latents](https://rome.baulab.info/).
-		- **Distribution specification.** What kind of conditional distributions could be used for training data for a simulator? For example, the [decision transformer](https://arxiv.org/abs/2106.01345) dataset is constructed for the intent of outcome-conditioning.
-		- **Other methods.** When pretrained simulators are modified by methods like [reinforcement learning from human feedback](https://arxiv.org/abs/2009.01325), [rejection sampling](https://lesswrong.com/posts/k7oxdbNaGATZbtEg3/redwood-research-s-current-project), [STaR](https://arxiv.org/abs/2203.14465), etc, how do we expect their behavior to diverge from the simulation objective?
+			- [Conditioning Generative Models for Alignment](https://lesswrong.com/posts/JqnkeqaPseTgxLgEL/conditioning-generative-models-for-alignment) by Jozdien
+			- [Training goals for large language models](https://lesswrong.com/posts/dWJNFHnC4bkdbovug/training-goals-for-large-language-models) by Johannes Treutlein
+			- [Strategy For Conditioning Generative Models](https://lesswrong.com/posts/HAz7apopTzozrqW2k/strategy-for-conditioning-generative-models) by James Lucassen and Evan Hubinger
+		- Instead of conditioning on a prompt ("observable" variables), we might also control generative models by [conditioning on latents](https://rome.baulab.info/).
+	- **Distribution specification.** What kind of conditional distributions could be used for training data for a simulator? For example, the [decision transformer](https://arxiv.org/abs/2106.01345) dataset is constructed for the intent of outcome-conditioning.
+	- **Other methods.** When pretrained simulators are modified by methods like [reinforcement learning from human feedback](https://arxiv.org/abs/2009.01325), [rejection sampling](https://lesswrong.com/posts/k7oxdbNaGATZbtEg3/redwood-research-s-current-project), [STaR](https://arxiv.org/abs/2203.14465), etc, how do we expect their behavior to diverge from the simulation objective?
 - **Simulacra alignment.** What can and what should we simulate, and how do we specify/control it?
 - **How does predictive learning generalize?** Many of the above considerations are influenced by how predictive learning generalizes out-of-distribution..
 	- What are the relevant inductive biases?
-		- What factors influence generalization behavior?
-		- Will powerful models predict [self-fulfilling](https://lesswrong.com/posts/JqnkeqaPseTgxLgEL/conditioning-generative-models-for-alignment) [prophecies](https://lesswrong.com/posts/dWJNFHnC4bkdbovug/training-goals-for-large-language-models)?
+	- What factors influence generalization behavior?
+	- Will powerful models predict [self-fulfilling](https://lesswrong.com/posts/JqnkeqaPseTgxLgEL/conditioning-generative-models-for-alignment) [prophecies](https://lesswrong.com/posts/dWJNFHnC4bkdbovug/training-goals-for-large-language-models)?
 - **Simulator inner alignment.** If simulators are not inner aligned, then many important properties like prediction orthogonality may not hold.
 	- Should we expect self-supervised predictive models to be aligned to the simulation objective, or to “care” about some other mesaobjective?
-		- Why mechanistically should mesaoptimizers form in predictive learning, versus for instance in reinforcement learning or GANs?
-		- How would we test if simulators are inner aligned?
+	- Why mechanistically should mesaoptimizers form in predictive learning, versus for instance in reinforcement learning or GANs?
+	- How would we test if simulators are inner aligned?
 
 ## Appendix: Quasi-simulators
 

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -294,4 +294,61 @@ describe('Markdown conversion', () => {
 			expect(markdown).not.toContain('\\begin{aligned}');
 		});
 	});
+
+	describe('nested lists', () => {
+		test('should give sibling items at the same depth the same indentation', () => {
+			const markdown = createMarkdownContent(
+				'<article><ul><li>A<ul><li>B1</li><li>B2</li><li>B3</li></ul></li></ul></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('- A\n\t- B1\n\t- B2\n\t- B3');
+		});
+
+		test('should indent by exactly one tab per level of nesting', () => {
+			const markdown = createMarkdownContent(
+				'<article><ul>' +
+					'<li>A1</li>' +
+					'<li>A2<ul>' +
+						'<li>B1</li>' +
+						'<li>B2<ul><li>C1</li><li>C2</li></ul></li>' +
+						'<li>B3</li>' +
+					'</ul></li>' +
+					'<li>A3</li>' +
+				'</ul></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain(
+				'- A1\n- A2\n\t- B1\n\t- B2\n\t\t- C1\n\t\t- C2\n\t- B3\n- A3'
+			);
+		});
+
+		test('should indent nested ordered lists without breaking numbering', () => {
+			const markdown = createMarkdownContent(
+				'<article><ol start="3"><li>one<ol><li>a</li><li>b</li></ol></li><li>two</li></ol></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('3. one\n\t1. a\n\t2. b\n4. two');
+		});
+
+		test('should indent an ordered list nested inside an unordered list', () => {
+			const markdown = createMarkdownContent(
+				'<article><ul><li>bullet<ol><li>first</li><li>second</li></ol></li></ul></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('- bullet\n\t1. first\n\t2. second');
+		});
+
+		test('should keep indenting continuation lines inside a list item', () => {
+			const markdown = createMarkdownContent(
+				'<article><ul><li><p>para one</p><p>para two</p></li><li>next</li></ul></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('- para one\n\tpara two\n- next');
+		});
+	});
 });

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -350,5 +350,15 @@ describe('Markdown conversion', () => {
 
 			expect(markdown).toContain('- para one\n\tpara two\n- next');
 		});
+
+		// Malformed but common markup
+		test('should indent a list that is a direct child of another list', () => {
+			const markdown = createMarkdownContent(
+				'<article><ul><li>A1</li><ul><li>B1</li><li>B2</li></ul><li>A2</li></ul></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('- A1\n\t- B1\n\t- B2\n- A2');
+		});
 	});
 });


### PR DESCRIPTION
Nested lists were converted with the wrong indentation.

The `listItem` rule applied indentation on top of the indentation the
enclosing `<li>` already adds, so the duplicate code was removed (d14221a3ecdc36779dbce9a3835ae9f924eda2bb).

That code was also handling indentation for malformed lists, so a
replacement for that case was added (d4eed1e9bfa3e9a60a73ef9f938b837abd2aebde).

```html
<ul>
  <li>A
    <ul>
      <li>B1</li>
      <li>B2</li>
      <li>B3
        <ul>
          <li>C1</li>
          <li>C2</li>
        </ul>
      </li>
    </ul>
  </li>
</ul>
```

Before:

```md
- A
	- B1
		- B2
		- B3
		- C1
				- C2
```

After:

```md
- A
	- B1
	- B2
	- B3
		- C1
		- C2
```