### PR TITLE
Fix backticks escaped inside code blocks

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -640,12 +640,15 @@ export function createMarkdownContent(content: string, url: string) {
 				|| '';
 			const code = codeElement.textContent || '';
 			
-			// Clean up the content and escape backticks
-			const cleanCode = code
-				.trim()
-				.replace(/`/g, '\\`');
-			
-			return `\n\`\`\`${language}\n${cleanCode}\n\`\`\`\n`;
+			// Backslash escapes are literal inside a fence, so escaping backticks here would
+			// corrupt the code. Only a line-leading run of three or more backticks can close
+			// the block, so grow the fence past the longest such run instead.
+			const cleanCode = code.trim();
+			const fenceSize = (cleanCode.match(/^`{3,}/gm) || [])
+				.reduce((size, run) => Math.max(size, run.length + 1), 3);
+			const fence = '`'.repeat(fenceSize);
+
+			return `\n${fence}${language}\n${cleanCode}\n${fence}\n`;
 		}
 	});
 

--- a/tests/expected/general--obsidian.md-blog-verify-obsidian-sync-encryption.md
+++ b/tests/expected/general--obsidian.md-blog-verify-obsidian-sync-encryption.md
@@ -38,7 +38,7 @@ First, get the salt used to derive your encryption key by following these steps:
 let data = await (await fetch('https://api.obsidian.md/vault/list', {method:'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({token: JSON.parse(localStorage.getItem('obsidian-account')).token})})).json();
 let vaults = [].concat(data.shared, data.vaults);
 let vault = vaults.find(v => v.id === app.internalPlugins.getEnabledPluginById('sync').vaultId);
-console.log(\`The salt of your vault ${vault.name} is: "${vault.salt}" with encryptionVersion ${vault.encryption_version}\`);
+console.log(`The salt of your vault ${vault.name} is: "${vault.salt}" with encryptionVersion ${vault.encryption_version}`);
 ```
 
 You should see a message containing your salt and encryption version:

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -294,4 +294,43 @@ describe('Markdown conversion', () => {
 			expect(markdown).not.toContain('\\begin{aligned}');
 		});
 	});
+
+	describe('fenced code blocks', () => {
+		test('should not escape backticks inside a code block', () => {
+			const markdown = createMarkdownContent(
+				'<article><pre><code class="language-javascript">res.write(`data: ${payload}`);</code></pre></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('res.write(`data: ${payload}`);');
+			expect(markdown).not.toContain('\\`');
+		});
+
+		test('should lengthen the fence when the code contains a fence line', () => {
+			const markdown = createMarkdownContent(
+				'<article><pre><code class="language-markdown">```js\nconst a = 1;\n```</code></pre></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('````markdown\n```js\nconst a = 1;\n```\n````');
+		});
+
+		test('should size the fence past the longest fence line in the code', () => {
+			const markdown = createMarkdownContent(
+				'<article><pre><code>a\n`````\nb</code></pre></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('``````\na\n`````\nb\n``````');
+		});
+
+		test('should keep the standard fence for code without backticks', () => {
+			const markdown = createMarkdownContent(
+				'<article><pre><code class="language-python">print("hi")</code></pre></article>',
+				'https://example.com'
+			);
+
+			expect(markdown).toContain('```python\nprint("hi")\n```');
+		});
+	});
 });


### PR DESCRIPTION
Fixes #353

## What

`preformattedCode` escaped every backtick in a code block. Backslash escapes are literal inside a fence, so the `\` reached the output and the code came out invalid.

## Why

Any code containing a backtick was corrupted. JS template literals are the common case — `` res.write(`...`) ``, `` fetch(`...`) `` — but it applies to shell command substitution and any language that uses the character.

`src/markdown.ts:646`:

```ts
const cleanCode = code
    .trim()
    .replace(/`/g, '\`');

return `\n\`\`\`${language}\n${cleanCode}\n\`\`\`\n`;
```

Turndown's own `fencedCodeBlock` rule already handles this correctly, by growing the fence past the longest backtick run in the code. This custom rule exists to read `data-lang`/`data-language`, which turndown's does not, and reimplemented the body handling with an escape instead. This restores the fence-growing behaviour and drops the escape.

Only a line-leading run of three or more backticks can close a fence, so backticks appearing mid-line need no treatment at all — which is why the escape was never necessary.

## How

```ts
const cleanCode = code.trim();
const fenceSize = (cleanCode.match(/^`{3,}/gm) || [])
    .reduce((size, run) => Math.max(size, run.length + 1), 3);
const fence = '`'.repeat(fenceSize);

return `\n${fence}${language}\n${cleanCode}\n${fence}\n`;
```

`String.matchAll` is ES2020 and `tsconfig.json` targets `es2019`, so this uses `match(/…/gm)`.

## One expected fixture changed

`tests/expected/general--obsidian.md-blog-verify-obsidian-sync-encryption.md` had the bug recorded in it — line 41 was:

```
console.log(\`The salt of your vault ${vault.name} is: …\`);
```

That is the same defect from obsidian.md's own blog. Corrected to bare backticks. It is the only expected file affected; the other 200+ are byte-identical.

## Verification

Four new tests in `tests/markdown.test.ts` under `fenced code blocks`. Confirmed **failing before the fix**:

```
1. should not escape backticks inside a code block
   expected '```javascript\nres.write(\`data: ${pa…' to contain 'res.write(`data: ${payload}`);'
2. should lengthen the fence when the code contains a fence line
   expected '```markdown\n\`\`\`js\nconst a = 1;\n…' to contain '````markdown\n```js\nconst a = 1;\n``…'
3. should size the fence past the longest fence line in the code
   expected '```\na\n\`\`\`\`\`\nb\n```' to contain '``````\na\n`````\nb\n``````'
```

Full suite after the fix:

```
$ TZ=UTC npx vitest run
PASS (446) FAIL (1)
1. Performance parse time per fixture (total including DOM parsing)
```

The perf failure is the 5s default timeout on my machine, not this change — it fails identically on a clean checkout of `main`.

`npm run build` and `npm run size` both pass:

```
✓ dist/index.js  88.4 KB gzip / 92 KB budget  [ok]
✓ dist/index.full.js  204.2 KB gzip / 215 KB budget  [ok]
All bundles within budget.
```

And against the URL from the issue, via `npx tsx src/cli.ts parse … --markdown`:

**before**
```
  res.write(\`event: endpoint
data: /messages?sessionId=${sessionId}

\`);
```

**after**
```
  res.write(`event: endpoint
data: /messages?sessionId=${sessionId}

`);
```

Not addressed here: the same article's code blocks without a language identifier, which #353 calls out as a separate request.
