### PR TITLE
Avoid forced CLI exit after extraction failure

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,6 @@ export async function parseSource(source: string | undefined, options: ParseOpti
 	if (isUrl && result.wordCount === 0 && !options.userAgent) {
 		try {
 			const botHtml = await fetchPage(source, BOT_UA, options.lang);
-
 			// Check for raw markdown before DOM parsing destroys whitespace
 			const rawMarkdown = extractRawMarkdown(botHtml);
 			if (rawMarkdown) {
@@ -159,7 +158,7 @@ export function createProgram(): Command {
 	program
 		.name('defuddle')
 		.description('Extract article content from web pages')
-		.version(version);
+			.version(version);
 
 	program
 		.command('parse')
@@ -188,7 +187,7 @@ export function createProgram(): Command {
 				}
 			} catch (error) {
 				console.error(ansi.red('Error:'), error instanceof Error ? error.message : 'Unknown error occurred');
-				process.exit(1);
+				process.exitCode = 1;
 			}
 		});
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,7 @@ export async function parseSource(source: string | undefined, options: ParseOpti
 	if (isUrl && result.wordCount === 0 && !options.userAgent) {
 		try {
 			const botHtml = await fetchPage(source, BOT_UA, options.lang);
+
 			// Check for raw markdown before DOM parsing destroys whitespace
 			const rawMarkdown = extractRawMarkdown(botHtml);
 			if (rawMarkdown) {
@@ -158,7 +159,7 @@ export function createProgram(): Command {
 	program
 		.name('defuddle')
 		.description('Extract article content from web pages')
-			.version(version);
+		.version(version);
 
 	program
 		.command('parse')

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -104,6 +104,7 @@ describe('CLI parseSource', () => {
 		expect(option?.short).toBe('-u');
 		// commander camelCases --user-agent → options.userAgent, which parseSource reads.
 		expect(option?.attributeName()).toBe('userAgent');
+	});
 
 	test('reports parse failures without forcing the process to exit', async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), 'defuddle-cli-error-'));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { readFileSync, rmSync, writeFileSync, mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -104,5 +104,24 @@ describe('CLI parseSource', () => {
 		expect(option?.short).toBe('-u');
 		// commander camelCases --user-agent → options.userAgent, which parseSource reads.
 		expect(option?.attributeName()).toBe('userAgent');
+
+	test('reports parse failures without forcing the process to exit', async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), 'defuddle-cli-error-'));
+		const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const previousExitCode = process.exitCode;
+		process.exitCode = undefined;
+
+		try {
+			await createProgram().parseAsync(['node', 'defuddle', 'parse', join(tempDir, 'missing.html')]);
+
+			expect(exit).not.toHaveBeenCalled();
+			expect(process.exitCode).toBe(1);
+			expect(error).toHaveBeenCalledWith('Error:', expect.stringContaining('ENOENT'));
+		} finally {
+			process.exitCode = previousExitCode;
+			vi.restoreAllMocks();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- **[100%] Replace `process.exit(1)` in the async CLI error handler with `process.exitCode = 1`, preserving failure status while allowing pending handles to close.**
- **[100%] Add a focused CLI regression proving parse failures report the error and exit 1 without forcing process teardown.**

## Verification

- **[100%] `npx --no-install vitest run tests/cli.test.ts` passes 9/9.**
- **[100%] `npm run build:node` passes.**
- **[100%] On Windows with Node 24.16.0, the failing Swagger URL now reports the expected extraction error and exits 1 without a libuv assertion.**

## Scope

- **[100%] No fetch/extraction changes; only CLI teardown/regression coverage.**